### PR TITLE
feat: Add difficulty display and solver metrics to UI

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/SolveRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/SolveRoutes.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.Serializable
 import will.sudoku.solver.Board
 import will.sudoku.solver.BoardReader
 import will.sudoku.solver.Coord
+import will.sudoku.solver.DifficultyRater
 import will.sudoku.solver.Solver
 import will.sudoku.solver.SolverWithMetrics
 
@@ -32,7 +33,9 @@ data class SolverMetricsResponse(
     val backtrackingCount: Int,
     val maxRecursionDepth: Int,
     val propagationPasses: Int,
-    val cellsProcessed: Int
+    val cellsProcessed: Int,
+    val difficulty: String? = null,
+    val techniquesUsed: List<String> = emptyList()
 )
 
 fun Route.solveRoutes() {
@@ -75,6 +78,9 @@ fun Route.solveRoutes() {
             val solver = SolverWithMetrics()
             val result = solver.solveWithMetrics(board)
             val solvedBoard = result.solvedBoard
+            
+            // Rate difficulty
+            val rating = DifficultyRater.rate(result.metrics)
 
             if (solvedBoard != null) {
                 call.respond(
@@ -86,7 +92,9 @@ fun Route.solveRoutes() {
                             backtrackingCount = result.metrics.backtrackingCount,
                             maxRecursionDepth = result.metrics.maxRecursionDepth,
                             propagationPasses = result.metrics.propagationPasses,
-                            cellsProcessed = result.metrics.cellsProcessed
+                            cellsProcessed = result.metrics.cellsProcessed,
+                            difficulty = rating.level.displayName,
+                            techniquesUsed = rating.techniquesUsed
                         )
                     )
                 )
@@ -100,7 +108,9 @@ fun Route.solveRoutes() {
                             backtrackingCount = result.metrics.backtrackingCount,
                             maxRecursionDepth = result.metrics.maxRecursionDepth,
                             propagationPasses = result.metrics.propagationPasses,
-                            cellsProcessed = result.metrics.cellsProcessed
+                            cellsProcessed = result.metrics.cellsProcessed,
+                            difficulty = rating.level.displayName,
+                            techniquesUsed = rating.techniquesUsed
                         )
                     )
                 )

--- a/web/src/main/resources/static/index.html
+++ b/web/src/main/resources/static/index.html
@@ -296,6 +296,14 @@
             setTimeout(() => result.classList.remove('visible'), 5000);
         }
 
+        // Show result message with HTML content
+        function showResultHTML(html, type = 'info') {
+            const result = document.getElementById('result');
+            result.innerHTML = html;
+            result.className = `result ${type} visible`;
+            setTimeout(() => result.classList.remove('visible'), 8000);
+        }
+
         // Set loading state
         function setLoading(loading) {
             document.querySelector('.container').classList.toggle('loading', loading);
@@ -318,12 +326,23 @@
                 if (data.solved) {
                     setPuzzleString(data.solution, false);
                     const metrics = data.metrics;
-                    showResult(
-                        `Solved in ${metrics.solveTimeMs.toFixed(2)}ms | ` +
-                        `Backtracking: ${metrics.backtrackingCount} | ` +
-                        `Depth: ${metrics.maxRecursionDepth}`,
-                        'success'
-                    );
+                    const difficulty = metrics.difficulty || 'Unknown';
+                    const difficultyClass = difficulty.toLowerCase();
+                    
+                    // Build result message with difficulty badge
+                    let resultHtml = `
+                        <span class="difficulty ${difficultyClass}">${difficulty}</span>
+                        Solved in ${metrics.solveTimeMs.toFixed(2)}ms
+                    `;
+                    
+                    // Add metrics details
+                    if (metrics.techniquesUsed && metrics.techniquesUsed.length > 0) {
+                        resultHtml += `<br><small>Techniques: ${metrics.techniquesUsed.join(', ')}</small>`;
+                    }
+                    
+                    resultHtml += `<br><small>Backtracking: ${metrics.backtrackingCount} | Depth: ${metrics.maxRecursionDepth} | Cells: ${metrics.cellsProcessed}</small>`;
+                    
+                    showResultHTML(resultHtml, 'success');
                 } else {
                     showResult(data.error || 'No solution found', 'error');
                 }


### PR DESCRIPTION
## Summary
- Add difficulty field to SolveResponse with techniquesUsed
- Update solve() to rate puzzle difficulty after solving
- Update UI to show difficulty badge with color coding
  - Easy: Green
  - Medium: Yellow/Orange  
  - Hard: Orange/Red
  - Expert: Purple
  - Master: Pink
- Display techniques used in result message
- Add showResultHTML() function for rich result display

## API Response
```json
{
  "solved": true,
  "solution": "...",
  "metrics": {
    "solveTimeMs": 1.23,
    "difficulty": "Medium",
    "techniquesUsed": ["hidden singles"],
    ...
  }
}
```

Closes #36