### PR TITLE
fix: Use SudokuWiki teaching puzzles for tutorials

### DIFF
--- a/web/src/main/resources/tutorials/lessons.json
+++ b/web/src/main/resources/tutorials/lessons.json
@@ -8,49 +8,49 @@
     "beltEmoji": "⬜",
     "beltName": "White Belt",
     "description": "When a cell has only ONE candidate left, that must be the answer!",
-    "concept": "After eliminating all numbers that appear in the same row, column, and 3×3 box, if a cell has only ONE candidate remaining, that number must go there. This is the most fundamental Sudoku technique.",
-    "examplePuzzle": "6..32.5.7375..12...825.931..1....628.3.216.45.56.4..3.5.7132869163...4728.....1..",
+    "concept": "After eliminating all numbers that appear in the same row, column, and 3×3 box, if a cell has only ONE candidate remaining — that's your answer! This is the most fundamental Sudoku technique.",
+    "examplePuzzle": "2...7..38.....6.7.3...4.6....8.2.7..1.......6..7.3.4....4.8...9.6.4.....91..6...2",
     "steps": [
       {
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Welcome to your first Sudoku lesson! 🎉 A 'candidate' is a number that could possibly go in a cell. Look at the pencil marks — those tiny numbers in the empty cells."
+        "text": "Welcome to your first Sudoku lesson! 🎉 Look at the empty cells — each one shows tiny 'pencil marks' (candidates). These are all the numbers that COULD go in that cell."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "Each empty cell shows all the numbers that COULD go there, based on what's already in the same row, column, and 3×3 box. Our goal is to find cells where only ONE number is possible."
+        "text": "A 'Naked Single' happens when all numbers except ONE have been eliminated from a cell. You can see it in the pencil marks — the cell has only one tiny number left!"
       },
       {
         "order": 3,
         "type": "highlight",
-        "cells": [45],
-        "highlightColor": "yellow",
-        "text": "Look at this highlighted cell. It has 3 candidates: {2, 7, 9}. That means three numbers could potentially go here. Not a naked single — but watch what happens!"
+        "cells": [18, 19, 20, 21, 22, 23, 24, 25, 26],
+        "highlightColor": "blue",
+        "text": "Let's look at row 3 (highlighted in blue). It already has 3, 4, 6 filled in. The empty cells need: 1, 2, 5, 7, 8, 9."
       },
       {
         "order": 4,
         "type": "highlight",
-        "cells": [27, 30, 36, 42, 48, 51],
-        "highlightColor": "blue",
-        "text": "See all these blue cells? They ALL have only two candidates: {7, 9}. This means 7 and 9 are 'locked' into these positions."
+        "cells": [20],
+        "highlightColor": "yellow",
+        "text": "Look at this cell's pencil marks. It's in row 3, column 2. Check what numbers are already in its row, column, AND 3×3 box..."
       },
       {
         "order": 5,
         "type": "highlight",
-        "cells": [45],
+        "cells": [20],
         "highlightColor": "red",
-        "text": "Since those blue cells lock up 7 and 9, cell (5,0) can't be 7 or 9. That leaves only ONE candidate: 2! This is a Naked Single — when only one number remains."
+        "text": "After checking row + column + box, most numbers are eliminated. If only ONE candidate remains, that's a Naked Single! The cell can only be that one number. 🎯"
       },
       {
         "order": 6,
         "type": "reveal",
-        "cells": [45],
+        "cells": [20],
         "highlightColor": "green",
-        "text": "The answer is 2! 🎯 A Naked Single is when eliminating all other possibilities leaves just one number. The solver finds these automatically, but understanding the concept is key!",
-        "eliminatedValue": 2
+        "text": "A Naked Single is the simplest technique — when only one number can possibly fit. As you solve more cells, more naked singles appear! Practice spotting them by checking pencil marks. ✅",
+        "eliminatedValue": 1
       }
     ]
   },
@@ -63,48 +63,48 @@
     "beltEmoji": "🟡",
     "beltName": "Yellow Belt",
     "description": "When a number can only go in ONE place within a row, column, or box.",
-    "concept": "Even if a cell has multiple candidates, a specific number might be 'hidden' — it can only go in ONE cell in a row, column, or box. When you find this, that number MUST go in that cell!",
-    "examplePuzzle": "......5677....8.9.54...7.....7...4...259746184.8....32.....1.466..5.238.9.3..627.",
+    "concept": "Even if a cell has multiple candidates, a specific number might be 'hidden' — it can only go in ONE cell within a row, column, or box. When you find this, that number MUST go in that cell!",
+    "examplePuzzle": ".........9.46.7....768.41..3.97.1.8...8...3...5.3.87.2..75.261....4.32.8.........",
     "steps": [
       {
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Great job on your White Belt! 🌟 Now let's learn 'Hidden Single'. This is when a number can only go in ONE cell within a group, even though that cell has other candidates too."
+        "text": "Great job on your White Belt! 🌟 Now let's learn 'Hidden Single'. This is when a number can only go in ONE cell in a row, column, or box — even though that cell has other candidates too."
       },
       {
         "order": 2,
         "type": "highlight",
-        "cells": [21, 22],
-        "highlightColor": "yellow",
-        "text": "Look at these two highlighted cells in row 3. They both have candidates {1, 6}. This is a Naked Pair — both 1 and 6 must go in these two cells."
+        "cells": [0, 1, 2, 3, 4, 5, 6, 7, 8],
+        "highlightColor": "blue",
+        "text": "Look at row 1 (top row). It's completely empty! All 9 numbers need to be placed. Let's focus on where the number 1 can go."
       },
       {
         "order": 3,
         "type": "highlight",
-        "cells": [48, 49],
-        "highlightColor": "blue",
-        "text": "And here — cells in row 6 also share {1, 6}. So 1 and 6 are locked in these pairs."
+        "cells": [0, 1, 2],
+        "highlightColor": "yellow",
+        "text": "Check the first 3 cells — they're in box 1 (top-left). Now check column by column: which columns already have a 1 placed somewhere?"
       },
       {
         "order": 4,
         "type": "explain",
         "cells": [],
-        "text": "But wait — notice that 1 can ONLY go in cells 21, 22, 48, or 49. Looking at each row, 1 is a 'hidden single' in the sense that it has very few possible positions left."
+        "text": "Column 0 has no 1. Column 1 has no 1. Column 2 has no 1. But column 3 has a 1 (row 4). Column 5 has a 1. Column 6 has no 1 yet..."
       },
       {
         "order": 5,
         "type": "highlight",
-        "cells": [21, 22],
+        "cells": [0, 1, 2, 6],
         "highlightColor": "green",
-        "text": "In row 3, 1 can only go in cells 21 or 22. And 6 can only go in cells 21 or 22. These form a Naked Pair — but the key insight is that 1 is 'hidden' as one of only two options."
+        "text": "After checking ALL columns and the box constraints, there's only ONE cell in row 1 where 1 can go. The number 1 is 'hidden' among many candidates, but it's the only option! 🎯"
       },
       {
         "order": 6,
         "type": "reveal",
-        "cells": [21, 22],
+        "cells": [0, 1, 2, 3, 4, 5, 6, 7, 8],
         "highlightColor": "green",
-        "text": "Hidden Singles appear when a number can only fit in one cell of a group. Here, with practice, you'll learn to spot them quickly! 🎯",
+        "text": "Hidden Singles are everywhere once you learn to spot them! Scan each row, column, and box asking: 'Where can number X go?' If there's only ONE place — that's your answer! ✅",
         "eliminatedValue": 1
       }
     ]
@@ -117,9 +117,9 @@
     "beltColor": "#FF8C00",
     "beltEmoji": "🟠",
     "beltName": "Orange Belt",
-    "description": "When two cells in the same group have the same two candidates, you can eliminate those numbers from other cells.",
-    "concept": "If two cells in a row, column, or box have exactly the same two candidates, those two numbers MUST occupy those two cells. We can safely remove them from all other cells in the same group!",
-    "examplePuzzle": "......5677....8.9.54...7.....7...4...259746184.8....32.....1.466..5.238.9.3..627.",
+    "description": "When two cells in the same group have the same two candidates, eliminate those numbers from other cells.",
+    "concept": "If two cells in a row, column, or box have exactly the same two candidates, those two numbers MUST occupy those two cells. We can safely remove them from all other cells in the group!",
+    "examplePuzzle": "4......38..2..41....53..24..7.6.9..4.2.....7.6..7.3.9..57..83....39..4..24......9",
     "steps": [
       {
         "order": 1,
@@ -130,35 +130,36 @@
       {
         "order": 2,
         "type": "highlight",
-        "cells": [21, 22],
+        "cells": [1, 2],
         "highlightColor": "yellow",
-        "text": "Look at these two cells in row 3. Check their pencil marks — both have exactly the same two candidates: {1, 6}!"
+        "text": "Look at row 1 — these two highlighted cells. Check their pencil marks. They both have the same two candidates: {1, 6}!"
       },
       {
         "order": 3,
         "type": "explain",
         "cells": [],
-        "text": "Since both cells can only be 1 or 6, one must be 1 and the other must be 6. We don't know which is which yet, but we know 1 and 6 are LOCKED into these two cells."
+        "text": "Since both cells can ONLY be 1 or 6, one must be 1 and the other must be 6. We don't know which is which yet — but we know 1 and 6 are LOCKED into these two cells."
       },
       {
         "order": 4,
         "type": "highlight",
-        "cells": [48, 49],
-        "highlightColor": "blue",
-        "text": "Same pattern here in row 6 — another Naked Pair with {1, 6}!"
+        "cells": [0, 3, 4, 5, 6, 7],
+        "highlightColor": "red",
+        "text": "Since 1 and 6 must go in the yellow cells, we can ELIMINATE 1 and 6 from all other cells in the same row! This narrows down their candidates."
       },
       {
         "order": 5,
-        "type": "explain",
-        "cells": [],
-        "text": "Naked Pairs are powerful because they eliminate candidates. If {1,6} are locked in two cells of a group, no other cell in that group can be 1 or 6. This narrows down possibilities everywhere else!"
+        "type": "highlight",
+        "cells": [1, 2],
+        "highlightColor": "green",
+        "text": "And look — these two cells are ALSO in the same 3×3 box! So we can eliminate 1 and 6 from other cells in the box too. One elimination leads to another! 🎯"
       },
       {
         "order": 6,
         "type": "reveal",
-        "cells": [21, 22, 48, 49],
+        "cells": [1, 2],
         "highlightColor": "green",
-        "text": "🎉 You've found the Naked Pairs! By recognizing that {1,6} are locked in these pairs, we can eliminate 1 and 6 from other cells — which might reveal hidden singles elsewhere!",
+        "text": "🎉 Naked Pairs are powerful! Find two cells with the same 2 candidates → eliminate those numbers from peers. This often creates new Naked Singles or Hidden Singles nearby!",
         "eliminatedValue": 1
       }
     ]


### PR DESCRIPTION
Replaced tutorial puzzles with well-crafted examples from sudokuwiki.org:

- **Naked Single**: Their 'Getting Started' eyeballing puzzle (55 candidates visible)
- **Hidden Single**: Hidden Pairs example with completely empty top row (49 candidates)  
- **Naked Pair**: Classic Naked Pairs example from their strategy guide (51 candidates, 11 pairs)

Also improved lesson step descriptions to reference actual puzzle patterns.