### PR TITLE
fix: Serve PWA manifest and registerSW.js

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/Application.kt
+++ b/web/src/main/kotlin/will/sudoku/web/Application.kt
@@ -79,6 +79,20 @@ fun Application.module() {
             )
         }
         
+        get("/manifest.webmanifest") {
+            call.respondText(
+                javaClass.classLoader.getResource("static/manifest.webmanifest")?.readText() ?: "{}",
+                io.ktor.http.ContentType.Application.Json
+            )
+        }
+        
+        get("/registerSW.js") {
+            call.respondText(
+                javaClass.classLoader.getResource("static/registerSW.js")?.readText() ?: "",
+                io.ktor.http.ContentType.Application.JavaScript
+            )
+        }
+        
         // Serve workbox library
         static("/workbox") {
             resources("static")


### PR DESCRIPTION
The vite-plugin-pwa generates manifest.webmanifest and registerSW.js but Ktor wasn't serving them. Added explicit GET routes.