### PR TITLE
fix: Remove stray quotes in Dashboard v-if causing InvalidCharacterError

### DIFF
--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -37,7 +37,7 @@
 
       <!-- Dashboard (home) -->
       <Dashboard
-        v-if="!tutorialMode && !tutorialSelectorOpen && !dailyMode && !playMode && !settingsOpen && !quizMode && !practiceMode && !leaderboardOpen && !achievementsOpen && !statsOpen && !savesOpen""
+        v-if="!tutorialMode && !tutorialSelectorOpen && !dailyMode && !playMode && !settingsOpen && !quizMode && !practiceMode && !leaderboardOpen && !achievementsOpen && !statsOpen && !savesOpen"
         :completed-tutorials="completedTutorials"
         :total-tutorials="tutorialList.length || 15"
         :is-dark="isDark"


### PR DESCRIPTION
## Bug
The Dashboard component had a trailing `""` at the end of its `v-if` directive (line 40 of `App.vue`):

```html
v-if="... && !savesOpen""
```

This caused Vue to interpret `"` as an attribute name and call `setAttribute(el, "\"", ...)`, which throws `InvalidCharacterError: Invalid qualified name: "\""` — crashing the app on mount and leaving users on a frozen splash screen.

## Fix
Removed the stray `""` — single character change.

## Testing
- Built and ran locally on port 25321
- Verified the app loads correctly in Chrome and Safari
- Dashboard renders without errors

Fixes the second crash bug found during local testing (the first was the `sharedPuzzle` TDZ error already fixed in `c816214`).