### PR TITLE
fix: Export getCellLabel from SudokuGrid setup

### DIFF
--- a/web-ui/src/components/SudokuGrid.vue
+++ b/web-ui/src/components/SudokuGrid.vue
@@ -319,6 +319,7 @@ export default {
       candidateGrids,
       cellCandidates,
       getCellClasses,
+      getCellLabel,
       isBottomBorder,
       selectCell,
       focusCell,


### PR DESCRIPTION
## Bug
The Daily Challenge page showed a blank area instead of the sudoku grid.

Root cause: `getCellLabel()` was defined in the SudokuGrid `setup()` function but **not included in the return statement**. When the template tried to call `getCellLabel(index)` for the `aria-label` attribute, it threw:

```
TypeError: e.getCellLabel is not a function
```

This crashed the grid rendering silently — the SudokuGrid component failed to mount its children, leaving just the header, timer, and number pad visible.

## Fix
Added `getCellLabel` to the setup return object (1 line).

## Testing
- Playwright E2E on iPhone viewport: grid now renders with 81 cells, 0 errors
- Daily Challenge loads correctly with puzzle, candidates, and number pad