### PR TITLE
fix: Blank Free Play page — confettiVisible and formatTime missing from return

### DIFF
--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -714,8 +714,7 @@ export default {
         if (solved && solved.solved) {
           stopTimer()
           playSound('solved')
-          confettiVisible,
-      formatTime.value = true
+          confettiVisible.value = true
         }
       }
     }
@@ -1285,7 +1284,9 @@ export default {
       sharePuzzle,
       handlePrint,
       handleShareImage,
-      handleKeyDown
+      handleKeyDown,
+      confettiVisible,
+      formatTime
     }
   }
 }


### PR DESCRIPTION
## Bug
When clicking "Free Play" on the dashboard, the page goes blank. No grid, no controls — just empty.

## Root Cause
Two issues in `App.vue` setup():

1. **`confettiVisible` and `formatTime` not returned** — The ConfettiCelebration component template references these, but they were never included in the `return {}` object. When `playMode=true`, Vue tries to render the confetti component and throws a runtime error, crashing the entire play mode view.

2. **Garbled code in `onCellUpdate`** — Line had stray `confettiVisible,` (comma expression, no-op) followed by `formatTime.value = true` (overwrites the formatTime function with `true`). Fixed to `confettiVisible.value = true`.

## Fix
- Added `confettiVisible` and `formatTime` to the return object
- Fixed the garbled confetti trigger code

## Testing
- `npm run build` passes ✅
- Deployed locally and verified Free Play loads correctly