### PR TITLE
fix: Handle 404 gracefully for undo-redo API endpoints

### DIFF
--- a/web-ui/src/api.js
+++ b/web-ui/src/api.js
@@ -43,7 +43,8 @@ export async function saveState(puzzle) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ puzzle })
   })
-  return response.json()
+  if (!response.ok) return { error: 'Undo/redo not available' }
+  return response.json().catch(() => ({}))
 }
 
 export async function undo() {
@@ -51,7 +52,8 @@ export async function undo() {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' }
   })
-  return response.json()
+  if (!response.ok) return { error: 'Undo not available' }
+  return response.json().catch(() => ({}))
 }
 
 export async function redo() {
@@ -59,7 +61,8 @@ export async function redo() {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' }
   })
-  return response.json()
+  if (!response.ok) return { error: 'Redo not available' }
+  return response.json().catch(() => ({}))
 }
 
 export async function getHistory() {
@@ -67,7 +70,8 @@ export async function getHistory() {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' }
   })
-  return response.json()
+  if (!response.ok) return { canUndo: false, canRedo: false, undoCount: 0, redoCount: 0 }
+  return response.json().catch(() => ({ canUndo: false, canRedo: false, undoCount: 0, redoCount: 0 }))
 }
 
 export async function fetchCandidates(puzzle) {


### PR DESCRIPTION
## Bug
When clicking Easy/Medium/Hard to generate a puzzle, the user gets an error toast "Failed to generate puzzle: SyntaxError...".

## Root Cause
The `generate` function calls `saveState()` and `loadHistoryState()` after successfully generating a puzzle. These call `/api/v1/undo-redo/*` endpoints which return 404 with empty body on this server. `api.js` called `response.json()` on the empty 404 response → `SyntaxError: Unexpected end of JSON input` → exception bubbles up to generate catch block → shows error toast to user.

The puzzle IS generated successfully on the server, but the error happens afterward during state saving.

## Fix
All undo-redo API functions now:
- Check `response.ok` before parsing JSON
- Return safe defaults on non-OK responses instead of throwing
- `.json()` calls have `.catch()` fallbacks

## Testing
- `npm run build` passes ✅
- Deployed locally, puzzle generation works without error