### PR TITLE
fix: Hint and 5 other endpoints returning 404 due to route double-nesting

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/CelebrationRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/CelebrationRoutes.kt
@@ -27,7 +27,7 @@ data class CelebrationResponse(
 fun Route.celebrationRoutes() {
     val celebrationSystem = CelebrationSystem()
 
-    post("/api/v1/celebration") {
+    post("/celebration") {
         val request = call.receive<CelebrationRequest>()
         
         val celebration = celebrationSystem.getCelebration(

--- a/web/src/main/kotlin/will/sudoku/web/DashboardRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DashboardRoutes.kt
@@ -25,7 +25,7 @@ data class DashboardResponse(
 fun Route.dashboardRoutes() {
     val dashboardSystem = DashboardSystem()
 
-    post("/api/v1/dashboard/report") {
+    post("/dashboard/report") {
         val request = call.receive<DashboardRequest>()
         
         val report = dashboardSystem.getStudentReport(request.studentId)

--- a/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
@@ -22,7 +22,7 @@ data class GenerateDifficultyResponse(
 )
 
 fun Route.difficultyRoutes() {
-    post("/api/v1/generate/difficulty") {
+    post("/generate/difficulty") {
         val request = call.receive<GenerateDifficultyRequest>()
         
         val difficulty = when {
@@ -58,7 +58,7 @@ fun Route.difficultyRoutes() {
         )
     }
     
-    get("/api/v1/generate/difficulty/{level}") {
+    get("/generate/difficulty/{level}") {
         val level = call.parameters["level"] ?: return@get call.respond(
             HttpStatusCode.BadRequest,
             mapOf("error" to "Missing difficulty level")

--- a/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
@@ -31,7 +31,7 @@ data class CellCoordinate(
 fun Route.hintRoutes() {
     val hintProvider = TeachingHintProvider()
 
-    post("/api/v1/hint") {
+    post("/hint") {
         val request = call.receive<HintRequest>()
         
         val puzzle = request.puzzle.filter { it.isDigit() }

--- a/web/src/main/kotlin/will/sudoku/web/ProgressRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/ProgressRoutes.kt
@@ -23,7 +23,7 @@ data class ProgressResponse(
 fun Route.progressRoutes() {
     val progressSystem = ProgressSystem()
 
-    post("/api/v1/progress") {
+    post("/progress") {
         val request = call.receive<ProgressRequest>()
         val progress = progressSystem.getProgress(request.userId)
         call.respond(

--- a/web/src/main/kotlin/will/sudoku/web/UserTestingRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/UserTestingRoutes.kt
@@ -16,7 +16,7 @@ fun Route.userTestingRoutes() {
     val surveySubmissions = mutableMapOf<String, SurveySubmission>()
     val learningMetrics = mutableMapOf<String, List<LearningMetrics>>()
     
-    post("/api/v1/user-testing/participant") {
+    post("/user-testing/participant") {
         try {
             val request = call.receive<CreateParticipantRequest>()
             
@@ -45,7 +45,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    post("/api/v1/user-testing/session") {
+    post("/user-testing/session") {
         try {
             val request = call.receive<CreateSessionRequest>()
             
@@ -74,7 +74,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    post("/api/v1/user-testing/session/{sessionId}/complete") {
+    post("/user-testing/session/{sessionId}/complete") {
         try {
             val sessionId = call.parameters["sessionId"] ?: throw IllegalArgumentException("Session ID required")
             val session = sessions[sessionId] ?: throw IllegalArgumentException("Session not found")
@@ -103,7 +103,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    post("/api/v1/user-testing/action") {
+    post("/user-testing/action") {
         try {
             val request = call.receive<RecordActionRequest>()
             
@@ -130,7 +130,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    post("/api/v1/user-testing/survey/submit") {
+    post("/user-testing/survey/submit") {
         try {
             val request = call.receive<SubmitSurveyRequest>()
             
@@ -159,7 +159,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    get("/api/v1/user-testing/protocol/{ageGroup}") {
+    get("/user-testing/protocol/{ageGroup}") {
         try {
             val ageGroupParam = call.parameters["ageGroup"] ?: throw IllegalArgumentException("Age group required")
             val ageGroup = AgeGroup.valueOf(ageGroupParam)
@@ -175,7 +175,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    get("/api/v1/user-testing/survey/{surveyId}") {
+    get("/user-testing/survey/{surveyId}") {
         try {
             val surveyId = call.parameters["surveyId"] ?: throw IllegalArgumentException("Survey ID required")
             val ageGroupParam = call.parameters["ageGroup"] ?: throw IllegalArgumentException("Age group required")
@@ -197,7 +197,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    get("/api/v1/user-testing/participant/{participantId}/progress") {
+    get("/user-testing/participant/{participantId}/progress") {
         try {
             val participantId = call.parameters["participantId"] ?: throw IllegalArgumentException("Participant ID required")
             
@@ -222,7 +222,7 @@ fun Route.userTestingRoutes() {
         }
     }
     
-    get("/api/v1/user-testing/features/{variant}") {
+    get("/user-testing/features/{variant}") {
         try {
             val variantParam = call.parameters["variant"] ?: throw IllegalArgumentException("Variant required")
             val variant = ABTestVariant.valueOf(variantParam)


### PR DESCRIPTION
## Bug
Clicking "Get Hint" returns an error. The hint endpoint returns 404.

## Root Cause
Several route files use absolute paths (e.g. `post("/api/v1/hint")`) inside a `route("api/v1") { }` block. Ktor nests route prefixes, creating `/api/v1/api/v1/hint` instead of `/api/v1/hint`.

The working routes (SolveRoutes, GenerateRoutes, etc.) use relative paths like `post("/solve")`.

## Affected Endpoints
- `/api/v1/hint` → was at `/api/v1/api/v1/hint` ❌
- `/api/v1/celebration` ❌
- `/api/v1/dashboard/report` ❌
- `/api/v1/generate/difficulty` ❌
- `/api/v1/progress` ❌
- `/api/v1/user-testing/*` ❌

## Fix
Changed all absolute paths to relative paths in 6 route files.

## Testing
- `./gradlew build` passes ✅
- `curl /api/v1/hint` returns proper hint response ✅
- `curl /api/hint` (legacy) also works ✅