### PR TITLE
fix: Hint button "puzzle should have 81 characters" error

### DIFF
--- a/web-ui/src/api.js
+++ b/web-ui/src/api.js
@@ -19,10 +19,12 @@ export async function generatePuzzle(difficulty = 'MEDIUM') {
 }
 
 export async function getHintForPuzzle(puzzle) {
+  // Backend expects digits only: 1-9 for filled, 0 for empty
+  const normalized = puzzle.replace(/\./g, '0')
   const response = await fetch(`${API_BASE}/hint`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ puzzle })
+    body: JSON.stringify({ puzzle: normalized })
   })
   return response.json()
 }


### PR DESCRIPTION
## Bug
Clicking "Get Hint" while playing shows error: "puzzle should have 81 character"

## Root Cause
`api.js` sends `puzzle` with `.` for empty cells (e.g. `"5.3..89..."`). 
Backend `HintRoutes.kt` filters to digits only then checks `puzzle.length != 81` — after filtering dots, the string has fewer than 81 chars.

## Fix
Replace `.` with `0` before sending to hint API. Backend interprets `0` as empty cell in `Board(values)`.

## Testing
- `curl /api/v1/hint` with `0`-filled puzzle returns hint ✅
- `npm run build` passes ✅