### PR TITLE
fix: clicking a cell highlights the wrong cell

### DIFF
--- a/web-ui/src/components/SudokuGrid.vue
+++ b/web-ui/src/components/SudokuGrid.vue
@@ -210,11 +210,16 @@ const selectCell = (index) => {
 
 const focusCell = async (index) => {
   await nextTick()
-  const input = inputs.value[index]
+  // Find the correct element by data-index, not by array position.
+  // The inputs/candidateGrids ref arrays may not align with cell indices
+  // because cells with candidates render <div> instead of <input>.
+  const allInputs = Array.isArray(inputs.value) ? inputs.value : [inputs.value]
+  const input = allInputs.find(el => el?.dataset?.index === String(index))
   if (input) {
     input.focus()
-  } else if (candidateGrids.value) {
-    // Find the candidate grid element with matching data-index
+    return
+  }
+  if (candidateGrids.value) {
     const grids = Array.isArray(candidateGrids.value) ? candidateGrids.value : [candidateGrids.value]
     const grid = grids.find(el => el?.dataset?.index === String(index))
     if (grid) {


### PR DESCRIPTION
## Bug
In Free Play mode, clicking a cell highlights a different cell.

## Root Cause
`focusCell(index)` used `inputs.value[index]` to find the DOM element. But `inputs` is a Vue template ref that only collects `<input>` elements — cells with candidates render `<div>` instead. So array position ≠ cell index.

When the wrong input gets `.focus()`, it fires `@focus="selectCell(index)"` which overwrites the correct selection.

Example: Click cell 5 → `inputs.value[5]` is actually cell 7 → cell 7 gets highlighted.

## Fix
Look up elements by `data-index` attribute instead of array position. Both `<input>` and candidate `<div>` already have `data-index` set.

## Testing
- `npm run build` passes ✅
- Deployed to local server, click cell → correct cell highlights ✅