### PR TITLE
fix: replace broken LayoutEncoder with JsonEncoder to prevent logback crashes

### DIFF
--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -303,8 +303,8 @@
           @update="onCellUpdate"
           @select="selectCell"
           @navigate="navigateToCell"
-          @undo="undo"
-          @redo="redo"
+          @undo="undoAction"
+          @redo="redoAction"
         />
 
         <!-- Mobile number pad (right below grid) -->
@@ -335,8 +335,8 @@
           @print="handlePrint"
           @share-image="handleShareImage"
           @hint="getHint"
-          @undo="undo"
-          @redo="redo"
+          @undo="undoAction"
+          @redo="redoAction"
           @toggle-candidates="showCandidates = !showCandidates"
         />
 
@@ -597,14 +597,14 @@ const handleKeyDown = (e) => {
   // Ctrl+Z / Cmd+Z for undo
   if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
     e.preventDefault()
-    undo()
+    undoAction()
     return
   }
 
   // Ctrl+Y / Cmd+Shift+Z for redo
   if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
     e.preventDefault()
-    redo()
+    redoAction()
     return
   }
 
@@ -998,14 +998,6 @@ const redoAction = async () => {
   } catch (e) {
     showToast('Error', 'Failed to redo: ' + e.message, 'error', true, redoAction)
   }
-}
-
-const undo = () => {
-  undoAction()
-}
-
-const redo = () => {
-  redoAction()
 }
 
 // Solve the puzzle

--- a/web-ui/src/components/DailyChallenge.vue
+++ b/web-ui/src/components/DailyChallenge.vue
@@ -221,7 +221,7 @@ const onCellSelect = (index: number): void => {
   selectedCell.value = index
 }
 
-const handleClick = (e: MouseEvent): void => {
+const handleClick = (e: Event): void => {
   // Deselect and close pad when tapping outside grid/pad
   const target = (e.target as HTMLElement).closest('.grid, .number-bar, .bar-btn, .pad-btn')
   if (!target) {

--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -1,13 +1,11 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.core.encoder.LayoutEncoder">
-            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
-                <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                    <prettyPrint>false</prettyPrint>
-                </jsonFormatter>
-                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-                <appendLineSeparator>true</appendLineSeparator>
-            </layout>
+        <encoder class="ch.qos.logback.contrib.json.classic.JsonEncoder">
+            <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                <prettyPrint>false</prettyPrint>
+            </jsonFormatter>
+            <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
+            <appendLineSeparator>true</appendLineSeparator>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Fixes the logback misconfiguration causing ~18 server crashes per 24 hours.

Root cause: logback.xml used ch.qos.logback.core.encoder.LayoutEncoder which does not exist in logback 1.4.x.

Fix: Replaced with JsonEncoder directly. Dependencies already present.

Testing: All tests pass, frontend builds successfully.