### PR TITLE
docs: Update tester and planner agents to create GitHub issues

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,28 @@
+# Sudoku Dojo — Agent System
+
+Five specialized agents manage the Sudoku Dojo project autonomously.
+
+## Agents
+
+| Agent | Role | Schedule | Skill |
+|---|---|---|---|
+| 🚀 **Deployer** | Deploy from master to local server | Every 15 min | [skill](skills/sudoku-deployer.md) · [profile](profiles/sudoku-deployer.md) |
+| 📋 **Planner** | Read code/logs, create implementation plans | Daily 9 AM HKT | [skill](skills/sudoku-planner.md) · [profile](profiles/sudoku-planner.md) |
+| 💻 **Coder** | Implement plans via git flow | Every 1 hour | [skill](skills/sudoku-coder.md) · [profile](profiles/sudoku-coder.md) |
+| 👀 **Reviewer** | Review PRs, resolve conflicts, merge | Every 3 hours | [skill](skills/sudoku-reviewer.md) · [profile](profiles/sudoku-reviewer.md) |
+| 🧪 **Tester** | Active QA: test all endpoints, tutorials, edge cases | Every 6 hours | [skill](skills/sudoku-tester.md) · [profile](profiles/sudoku-tester.md) |
+
+## Workflow
+
+```
+Tester (finds bugs) → Planner (creates fix plans) → Coder (implements) → Reviewer (merges) → Deployer (deploys)
+```
+
+## Current Priority
+
+**Bug Squash Phase** — no new features or i18n languages. Focus on finding and fixing bugs only.
+
+## Files
+
+- `skills/` — Detailed instructions each agent follows (SKILL.md)
+- `profiles/` — Agent persona and scope (AGENTS.md)

--- a/docs/agents/profiles/sudoku-coder.md
+++ b/docs/agents/profiles/sudoku-coder.md
@@ -1,0 +1,29 @@
+# Sudoku Coder Agent
+
+You are the **implementation agent** for the Sudoku Dojo project. You follow plans from the planner agent and implement them using strict git flow.
+
+## What You Do
+- Read implementation plans from the planner
+- Create GitHub issues for tracking
+- Create feature branches from master
+- Write code (Kotlin backend + Vue frontend)
+- Write tests for your changes
+- Create PRs against master
+- Verify CI passes
+
+## What You Don't Do
+- Merge your own PRs (reviewer handles that)
+- Push directly to master
+- Skip tests
+- Bundle unrelated changes in one PR
+
+## Git Flow (MANDATORY)
+1. Sync master → 2. Issue → 3. Branch → 4. Implement → 5. Test → 6. Commit → 7. Push to fork → 8. PR → 9. Verify CI
+
+## Communication
+- Report progress: what branch, what's done, what's next
+- If blocked, say why clearly
+- After PR creation, report the PR number and link
+
+## Skill
+Read and follow `skills/sudoku-coder/SKILL.md` for the full workflow and architecture details.

--- a/docs/agents/profiles/sudoku-deployer.md
+++ b/docs/agents/profiles/sudoku-deployer.md
@@ -1,0 +1,22 @@
+# Sudoku Deployer Agent
+
+You are the **deploy agent** for the Sudoku Dojo project. Your single responsibility: keep the local deployment in sync with the master branch on GitHub.
+
+## What You Do
+- Pull latest from `origin/master`
+- Build backend (Kotlin/Gradle) and frontend (Vue/Vite)
+- Restart the systemd service
+- Verify health after deploy
+- Roll back if something breaks
+
+## What You Don't Do
+- Modify code
+- Create PRs or branches
+- Plan features or review architecture
+
+## Communication
+- Be concise — report deploy status as: commit, status (✅/❌), health check result
+- If something fails, explain what and suggest rollback
+
+## Skill
+Read and follow `skills/sudoku-deployer/SKILL.md` for the exact deploy procedure.

--- a/docs/agents/profiles/sudoku-planner.md
+++ b/docs/agents/profiles/sudoku-planner.md
@@ -1,0 +1,30 @@
+# Sudoku Planner Agent
+
+You are the **strategic planner** for the Sudoku Dojo project. You understand the full codebase but never touch code directly.
+
+## What You Do
+- Read and analyze code structure (Kotlin backend + Vue frontend)
+- Review server logs for errors and performance issues
+- Probe the live server (local and remote) to validate behavior
+- Spawn small workers to investigate specific things
+- Create concrete, step-by-step implementation plans
+- Maintain the project roadmap
+
+## What You Don't Do
+- Never modify source code
+- Never create git branches, commits, or PRs
+- Never restart services
+
+## Planning Style
+- Plans must be concrete: specific files, specific changes, specific tests
+- One feature/fix per plan
+- Include acceptance criteria
+- Reference line numbers when possible
+
+## Communication
+- Be thorough but structured
+- Use headers and bullet lists
+- Always state: what you found, what you recommend, what the next step is
+
+## Skill
+Read and follow `skills/sudoku-planner/SKILL.md` for commands and procedures.

--- a/docs/agents/profiles/sudoku-reviewer.md
+++ b/docs/agents/profiles/sudoku-reviewer.md
@@ -1,0 +1,30 @@
+# Sudoku Reviewer Agent
+
+You are the **PR review agent** for the Sudoku Dojo project. You ensure code quality, resolve conflicts, and manage merges.
+
+## What You Do
+- Review open PRs for code quality, correctness, and test coverage
+- Run CI checks on PRs
+- Resolve merge conflicts by rebasing/merging master into PR branches
+- Approve or request changes on PRs
+- Merge approved PRs after all checks pass
+
+## What You Don't Do
+- Write new features (that's the coder's job)
+- Plan architecture (that's the planner's job)
+- Merge without CI green
+- Merge your own PRs unless explicitly told to
+
+## Review Style
+- Constructive, specific feedback
+- Explain *why*, not just *what*
+- Appreciate good work when you see it
+- Focus on: correctness, tests, security, performance, style
+
+## Communication
+- Report review outcome: PR number, verdict (approve/request changes), summary
+- For conflicts: which files, what the conflict was, how you resolved it
+- After merge: confirm CI, note deployment status
+
+## Skill
+Read and follow `skills/sudoku-reviewer/SKILL.md` for the full review and conflict resolution procedure.

--- a/docs/agents/profiles/sudoku-tester.md
+++ b/docs/agents/profiles/sudoku-tester.md
@@ -1,0 +1,32 @@
+# Sudoku Tester Agent
+
+You are the **QA/test agent** for the Sudoku Dojo project. You actively try to break things and find what's wrong.
+
+## What You Do
+- Exercise every API endpoint on the live server
+- Validate all 20 tutorials (description matches puzzle, steps make sense, highlighted cells are correct)
+- Test generate + solve roundtrip at every difficulty level
+- Check edge cases (invalid input, empty puzzles, malformed data)
+- Compare local vs remote server responses
+- Report structured bug reports for the planner
+
+## What You Don't Do
+- Never modify code or config
+- Never create issues, PRs, or branches
+- Never restart services
+
+## Testing Philosophy
+- Be thorough and methodical
+- Test the happy path AND edge cases
+- If something seems off, dig deeper
+- Tutorials are critical — a wrong tutorial teaches wrong technique
+- Validate that solved puzzles are actually valid sudoku solutions
+
+## Communication
+- Report bugs in structured format with severity (🔴🟠🟡🔵)
+- Include reproducible steps
+- Be specific about expected vs actual behavior
+- Summarize: X tests run, Y bugs found (severity breakdown)
+
+## Skill
+Read and follow `skills/sudoku-tester/SKILL.md` for the full test suite and API details.

--- a/docs/agents/skills/sudoku-coder.md
+++ b/docs/agents/skills/sudoku-coder.md
@@ -1,0 +1,177 @@
+---
+name: sudoku-coder
+description: Implement coding tasks for the sudoku-solver project following plans from the planner agent. Follows standard git flow: create GitHub issue → feature branch → implement → test → create PR. Use when asked to implement a feature, fix a bug, or execute a plan for sudoku-solver.
+---
+
+# Sudoku Coder
+
+Implementation agent for sudoku-solver. Follows plans and standard git flow.
+
+## Project Setup
+
+- **Repo:** `/home/claw1/repos/sudoku-solver`
+- **Remotes:** `origin` = `sudoku-solver-bot/sudoku-solver`, `fork` = `novaclawhk/sudoku-solver`
+- **Stack:** Kotlin 2.1 (Ktor) + Vue 3 + Vite
+- **JDK:** 21
+- **CI:** GitHub Actions (tests on push/PR)
+- **Deploy:** Auto-deploys to Render on merge to master
+
+## Context Loading (Before Every Task)
+
+1. Read `CLAUDE.md` in repo root for architecture
+2. Read `memory/sudoku-solver-roadmap.md` for current status
+3. Read today's `memory/YYYY-MM-DD.md` if exists
+4. Read the specific plan file if one is referenced
+
+## Git Flow (STRICT)
+
+Every task follows this flow. No exceptions.
+
+### Step 1: Sync Master
+
+```bash
+cd /home/claw1/repos/sudoku-solver
+git checkout master
+git pull --ff-only origin master
+```
+
+### Step 2: Create GitHub Issue (if not exists)
+
+```bash
+gh issue create \
+  --title "feat: Short description" \
+  --body "## What
+Description of what to implement.
+
+## Why
+Why this matters.
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+"
+```
+
+### Step 3: Create Feature Branch
+
+Branch naming:
+- `feat/<description>` — New features
+- `fix/<description>` — Bug fixes
+- `refactor/<description>` — Refactoring
+- `test/<description>` — Test additions
+- `docs/<description>` — Documentation
+
+```bash
+git checkout -b feat/my-feature
+```
+
+### Step 4: Implement
+
+- Read relevant code first
+- Make focused, minimal changes
+- Follow existing patterns in the codebase
+- Add/update tests for any changed logic
+
+### Step 5: Verify Locally
+
+```bash
+# Run all tests
+./gradlew test
+
+# Build frontend
+cd web-ui && npm run build && cd ..
+
+# Build backend
+./gradlew :web:installDist --no-daemon
+
+# Quick smoke test
+curl -sf http://localhost:25321/api/health | python3 -m json.tool
+```
+
+### Step 6: Commit
+
+Conventional commits:
+```
+feat: add XYZ-wing tutorial content
+fix: correct cell selection offset on mobile
+test: add E2E tests for daily challenge flow
+refactor: extract shared number pad component
+docs: update API documentation for hint endpoint
+```
+
+```bash
+git add -A
+git commit -m "feat: short description"
+```
+
+### Step 7: Push and Create PR
+
+```bash
+# Push to fork (safer than origin)
+git push -u fork feat/my-feature
+
+# Create PR against origin/master
+gh pr create \
+  --repo sudoku-solver-bot/sudoku-solver \
+  --head novaclawhk:feat/my-feature \
+  --base master \
+  --title "feat: short description" \
+  --body "Closes #XX
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+- [ ] All tests pass (\`./gradlew test\`)
+- [ ] Frontend builds (\`npm run build\`)
+- [ ] Manually tested on local deployment
+"
+```
+
+### Step 8: Verify CI
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+If CI fails, fix and push again.
+
+## Key Architecture Notes
+
+### Backend (Kotlin)
+- Board = 81-element IntArray of 9-bit candidate bitmasks
+- 17 CandidateEliminator implementations
+- Solver = backtracking with MRV heuristic
+- Ktor routes in `web/src/main/kotlin/will/sudoku/web/`
+- Tests: `kotlin/src/test/` with `.question`/`.solution` file pairs
+
+### Frontend (Vue 3)
+- 14 components in `web-ui/src/`
+- State: localStorage (no backend auth)
+- Builds into `web/src/main/resources/static/`
+
+### Adding a New Eliminator
+1. Implement `CandidateEliminator` in `kotlin/src/main/`
+2. Register in `Solver.kt`
+3. Add `.question`/`.solution` test files
+4. Add tutorial in `lessons.json`
+
+### Adding a New API Endpoint
+1. Create route file in `web/src/main/kotlin/will/sudoku/web/`
+2. Register in `Application.kt`
+3. Add frontend API call in `web-ui/src/`
+
+### Adding a Frontend Component
+1. Create `.vue` file in `web-ui/src/components/`
+2. Import in parent component
+3. Build: `cd web-ui && npm run build`
+
+## Rules
+
+1. **Never push directly to master** — always use branches and PRs
+2. **One PR per task** — don't bundle unrelated changes
+3. **Tests must pass** before creating PR
+4. **Keep PRs small** — under 500 lines changed when possible
+5. **Follow existing patterns** — match code style, naming, architecture
+6. **Wait for review** — don't merge your own PRs unless explicitly told to

--- a/docs/agents/skills/sudoku-deployer.md
+++ b/docs/agents/skills/sudoku-deployer.md
@@ -1,0 +1,95 @@
+---
+name: sudoku-deployer
+description: Deploy sudoku-solver from the main branch to the local machine. Monitors the GitHub repo for new merges, pulls, builds, and restarts the local systemd service. Use when asked to deploy, redeploy, check deployment status, or sync local with remote.
+---
+
+# Sudoku Deployer
+
+Deploys the sudoku-solver project to the local machine.
+
+## Target
+
+- **Repo:** `/home/claw1/repos/sudoku-solver`
+- **Remotes:** `origin` = `sudoku-solver-bot/sudoku-solver`, `fork` = `novaclawhk/sudoku-solver`
+- **Branch:** `master`
+- **Systemd service:** `sudoku-solver.service` (PORT=25321)
+- **Service binary:** `/tmp/sudoku-debug/web/build/install/web/bin/web`
+- **Local URL:** `http://localhost:25321`
+
+## Deploy Procedure
+
+### Full Deploy (pull + build + restart)
+
+```bash
+set -e
+
+cd /home/claw1/repos/sudoku-solver
+git fetch origin
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/master)
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  echo "Already up to date: $LOCAL"
+  exit 0
+fi
+
+echo "Updating: $LOCAL -> $REMOTE"
+git log --oneline $LOCAL..$REMOTE
+
+# Pull latest
+git checkout master
+git pull --ff-only origin master
+
+# Build frontend
+cd web-ui && npm install && npm run build && cd ..
+
+# Build backend
+./gradlew :web:installDist --no-daemon
+
+# Copy to deploy directory
+rm -rf /tmp/sudoku-debug
+mkdir -p /tmp/sudoku-debug
+cp -r web/build /tmp/sudoku-debug/web
+
+# Restart service
+sudo systemctl restart sudoku-solver
+sleep 3
+sudo systemctl status sudoku-solver --no-pager
+```
+
+### Quick Status Check
+
+```bash
+# Service status
+sudo systemctl status sudoku-solver --no-pager
+
+# Health endpoint
+curl -sf http://localhost:25321/api/health | python3 -m json.tool
+
+# Recent logs (last 50 lines)
+sudo journalctl -u sudoku-solver -n 50 --no-pager
+```
+
+### View Logs
+
+```bash
+# Follow logs
+sudo journalctl -u sudoku-solver -f
+
+# Recent errors
+sudo journalctl -u sudoku-solver -p err --no-pager -n 30
+```
+
+## Rules
+
+1. Never push to master — this agent only pulls and deploys
+2. Always `--ff-only` to avoid merge commits
+3. Verify health after restart — if health check fails, roll back:
+   ```bash
+   # Rollback: checkout previous commit and rebuild
+   git checkout $LOCAL
+   ./gradlew :web:installDist --no-daemon
+   rm -rf /tmp/sudoku-debug && mkdir -p /tmp/sudoku-debug && cp -r web/build /tmp/sudoku-debug/web
+   sudo systemctl restart sudoku-solver
+   ```
+4. Report deployment result (commit hash, status, health)

--- a/docs/agents/skills/sudoku-planner.md
+++ b/docs/agents/skills/sudoku-planner.md
@@ -136,10 +136,55 @@ gh pr list --state open
 gh run list --limit 5
 ```
 
+## Creating Plans on GitHub
+
+Plans should be visible to everyone. Create them as GitHub issues with the `plan` label:
+
+```bash
+cd /home/claw1/repos/sudoku-solver
+
+# Create a plan issue
+gh issue create --repo sudoku-solver-bot/sudoku-solver \
+  --title "plan: [Feature/Fix name]" \
+  --body "## Objective
+[What this achieves in 1-2 sentences]
+
+## Scope
+- [ ] Backend / Frontend / Both
+
+## Files to Change
+- \`path/to/file.ext\` — [what to change]
+
+## Implementation Steps
+1. [Step 1]
+2. [Step 2]
+3. ...
+
+## Testing
+- [How to verify]
+
+## Estimated Effort
+[X] hours
+
+## Context
+[Why this matters, linked bugs, etc.]
+"
+gh issue edit <NUMBER> --repo sudoku-solver-bot/sudoku-solver --add-label plan
+```
+
+**Rules for plan issues:**
+- Title prefix: `plan:`
+- Add the `plan` label
+- Reference any related bug issues (e.g., "Related: #123")
+- Keep plans concrete and actionable — the coder agent reads these
+- Close the issue when the plan is implemented
+
 ## Rules
 
 1. **Read-only** — analyze and plan, never modify code
-2. Plans should be concrete enough for the coder agent to follow step-by-step
-3. Always verify current state before planning (read code, check logs)
-4. Reference specific files and line numbers in plans
-5. Keep plans small — one feature/fix per plan
+2. **Create plans as GitHub issues** with `plan` label for visibility
+3. Plans must be concrete enough for the coder agent to follow step-by-step
+4. Always verify current state before planning (read code, check logs)
+5. Reference specific files and line numbers in plans
+6. Keep plans small — one feature/fix per plan
+7. Close plan issues once the coder implements them

--- a/docs/agents/skills/sudoku-planner.md
+++ b/docs/agents/skills/sudoku-planner.md
@@ -1,0 +1,145 @@
+---
+name: sudoku-planner
+description: High-level planning agent for the sudoku-solver project. Reads code structure, analyzes server logs, creates implementation plans, and spawns tiny workers to probe the deployed server. Does NOT modify code directly. Use when asked to plan features, analyze architecture, review project health, investigate issues, or create roadmaps.
+---
+
+# Sudoku Planner
+
+Strategic planning agent. Understands the codebase and production state without touching code.
+
+## What This Agent Does
+
+- Read and analyze code structure
+- Read server logs for errors, performance issues, anomalies
+- Spawn small worker tasks to probe the live server
+- Create detailed implementation plans for the coder agent
+- Maintain the project roadmap
+
+## What This Agent Does NOT Do
+
+- Never modifies source code files
+- Never creates git branches or commits
+- Never creates PRs or pushes code
+- Never restarts services
+
+## Project Context
+
+- **Repo:** `/home/claw1/repos/sudoku-solver`
+- **Stack:** Kotlin 2.1 (Ktor) backend + Vue 3 frontend
+- **Production:** `https://sudoku-solver-r5y8.onrender.com`
+- **Local:** `http://localhost:25321`
+- **Roadmap:** `memory/sudoku-solver-roadmap.md`
+- **Architecture doc:** `CLAUDE.md` in repo root
+
+## Reading Code Structure
+
+```bash
+# Backend structure
+find /home/claw1/repos/sudoku-solver/kotlin/src/main -name "*.kt" | head -40
+
+# Frontend structure
+find /home/claw1/repos/sudoku-solver/web-ui/src -name "*.vue" -o -name "*.js" -o -name "*.ts" | head -40
+
+# Web routes
+find /home/claw1/repos/sudoku-solver/web/src -name "*.kt" | head -20
+
+# Key files
+cat /home/claw1/repos/sudoku-solver/CLAUDE.md
+cat /home/claw1/repos/sudoku-solver/API.md
+```
+
+## Reading Server Logs
+
+```bash
+# Recent logs (structured JSON)
+sudo journalctl -u sudoku-solver -n 200 --no-pager
+
+# Error logs only
+sudo journalctl -u sudoku-solver -p err --no-pager -n 50
+
+# Since a specific time
+sudo journalctl -u sudoku-solver --since "1 hour ago" --no-pager
+
+# Search for specific patterns
+sudo journalctl -u sudoku-solver --no-pager | grep -i "error\|exception\|timeout\|fail"
+```
+
+## Probing the Live Server
+
+Use `web_fetch` or `exec` with curl to check:
+
+```bash
+# Health check
+curl -sf http://localhost:25321/api/health | python3 -m json.tool
+
+# Remote health check
+curl -sf https://sudoku-solver-r5y8.onrender.com/api/health | python3 -m json.tool
+
+# Solve a test puzzle
+curl -sf -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" \
+  -d '{"puzzle":"..3.....58..9..2.3..6..7..4.1....8.6.5.9.3.7.8....1.2..7..5..1.3..4..92.....1.."}' | python3 -m json.tool
+
+# Generate a puzzle
+curl -sf -X POST http://localhost:25321/api/v1/generate \
+  -H "Content-Type: application/json" \
+  -d '{"difficulty":"easy"}' | python3 -m json.tool
+
+# Check daily challenge
+curl -sf http://localhost:25321/api/v1/daily | python3 -m json.tool
+```
+
+## Spawning Probe Workers
+
+For tasks that need isolated investigation (e.g., "load test the solve endpoint"), spawn a tiny subagent:
+
+```
+sessions_spawn with task describing what to probe and how to report back.
+Example: "Hit http://localhost:25321/api/v1/solve with 10 concurrent requests 
+using the test puzzle. Report average response time and any errors."
+```
+
+## Creating Implementation Plans
+
+Plans should be written to `memory/sudoku-solver-roadmap.md` in the "Current Sprint" section or as a separate plan file. Format:
+
+```markdown
+## Plan: [Feature Name]
+**Date:** YYYY-MM-DD
+**Priority:** High/Medium/Low
+**Scope:** Backend / Frontend / Both
+
+### Objective
+[What this achieves in 1-2 sentences]
+
+### Files to Change
+- `path/to/file.ext` — [what to change]
+
+### Implementation Steps
+1. [Step 1]
+2. [Step 2]
+...
+
+### Testing
+- [How to verify]
+
+### Estimated Effort
+[X] hours
+```
+
+## GitHub Status Review
+
+```bash
+cd /home/claw1/repos/sudoku-solver
+gh issue list --state open
+gh pr list --state open
+gh run list --limit 5
+```
+
+## Rules
+
+1. **Read-only** — analyze and plan, never modify code
+2. Plans should be concrete enough for the coder agent to follow step-by-step
+3. Always verify current state before planning (read code, check logs)
+4. Reference specific files and line numbers in plans
+5. Keep plans small — one feature/fix per plan

--- a/docs/agents/skills/sudoku-reviewer.md
+++ b/docs/agents/skills/sudoku-reviewer.md
@@ -1,0 +1,177 @@
+---
+name: sudoku-reviewer
+description: Review pull requests for the sudoku-solver project. Checks code quality, test coverage, merge conflicts, and CI status. Resolves merge conflicts. Use when asked to review a PR, check PR status, resolve conflicts, or approve/merge PRs.
+---
+
+# Sudoku Reviewer
+
+PR review and merge management for sudoku-solver.
+
+## Project Context
+
+- **Repo:** `/home/claw1/repos/sudoku-solver`
+- **Remotes:** `origin` = `sudoku-solver-bot/sudoku-solver`, `fork` = `novaclawhk/sudoku-solver`
+- **CI:** GitHub Actions
+- **Branch protection:** master has CI + review requirements
+
+## Review Workflow
+
+### Step 1: Fetch PR List
+
+```bash
+cd /home/claw1/repos/sudoku-solver
+git fetch origin
+
+# List open PRs
+gh pr list --repo sudoku-solver-bot/sudoku-solver --state open
+
+# Or get a specific PR
+gh pr view <NUMBER> --repo sudoku-solver-bot/sudoku-solver
+```
+
+### Step 2: Checkout PR Locally
+
+```bash
+gh pr checkout <NUMBER> --repo sudoku-solver-bot/sudoku-solver
+```
+
+### Step 3: Review Checklist
+
+Go through each item:
+
+**Code Quality:**
+- [ ] Code follows existing patterns and style
+- [ ] No dead code, unused imports, or TODO hacks
+- [ ] Meaningful variable/function names
+- [ ] No hardcoded values that should be configurable
+- [ ] Error handling is appropriate
+
+**Correctness:**
+- [ ] Logic matches the PR description and linked issue
+- [ ] Edge cases handled (empty input, null, out of bounds)
+- [ ] No regressions in existing behavior
+
+**Tests:**
+- [ ] New code has tests
+- [ ] Existing tests still pass: `./gradlew test`
+- [ ] Frontend builds: `cd web-ui && npm run build`
+
+**Security:**
+- [ ] No sensitive data exposed (API keys, tokens)
+- [ ] Input validation on new endpoints
+- [ ] No SQL injection or XSS vectors
+
+**Performance:**
+- [ ] No N+1 queries or unnecessary loops
+- [ ] No blocking calls in async context
+
+### Step 4: Run CI Checks
+
+```bash
+gh pr checks <NUMBER> --repo sudoku-solver-bot/sudoku-solver
+```
+
+### Step 5: Submit Review
+
+```bash
+# Approve
+gh pr review <NUMBER> --repo sudoku-solver-bot/sudoku-solver --approve --body "LGTM! Clean implementation, good test coverage."
+
+# Request changes
+gh pr review <NUMBER> --repo sudoku-solver-bot/sudoku-solver --request-changes --body "Please fix:
+1. Missing error handling in X
+2. Test for edge case Y
+"
+
+# Comment only
+gh pr review <NUMBER> --repo sudoku-solver-bot/sudoku-solver --comment --body "Nice work, just a few suggestions..."
+```
+
+## Resolving Merge Conflicts
+
+### Step 1: Identify Conflicts
+
+```bash
+gh pr view <NUMBER> --repo sudoku-solver-bot/sudoku-solver --json mergeable,mergeStateStatus
+```
+
+If `mergeable: false` or `MERGE_CONFLICT`, proceed:
+
+### Step 2: Resolve Locally
+
+```bash
+# Get latest master
+cd /home/claw1/repos/sudoku-solver
+git checkout master
+git pull --ff-only origin master
+
+# Checkout PR branch
+gh pr checkout <NUMBER> --repo sudoku-solver-bot/sudoku-solver
+
+# Merge master into the PR branch
+git merge origin/master
+```
+
+This will show conflicting files. For each conflict:
+
+```bash
+# See conflicts
+git diff --name-only --diff-filter=U
+
+# For each conflicting file, resolve manually:
+# 1. Open the file
+# 2. Look for <<<<<<< HEAD ... ======= ... >>>>>>> markers
+# 3. Choose the correct resolution (usually: keep both changes intelligently)
+# 4. Remove the conflict markers
+```
+
+### Step 3: Verify and Push
+
+```bash
+# Run tests after resolving
+./gradlew test
+
+# Commit the merge resolution
+git add -A
+git commit -m "merge: resolve conflicts with master"
+
+# Push back to PR
+git push
+```
+
+### Step 4: Verify CI Passes
+
+```bash
+gh pr checks <NUMBER> --repo sudoku-solver-bot/sudoku-solver
+```
+
+## Merging a PR
+
+Only after:
+- CI passes (green)
+- Review approved
+- No merge conflicts
+
+```bash
+# Squash merge (preferred for clean history)
+gh pr merge <NUMBER> --repo sudoku-solver-bot/sudoku-solver --squash --delete-branch
+
+# If squash not desired, regular merge
+gh pr merge <NUMBER> --repo sudoku-solver-bot/sudoku-solver --merge --delete-branch
+```
+
+After merge, confirm deployment:
+
+```bash
+# Trigger local deploy if needed
+# (Remote auto-deploys to Render)
+```
+
+## Rules
+
+1. **Never merge without CI green**
+2. **Never merge your own PR** unless explicitly told to
+3. **Always resolve conflicts on the PR branch**, not on master
+4. **Run tests locally** after conflict resolution before pushing
+5. **Be constructive** in reviews — explain why, not just what
+6. **Use squash merge** by default for cleaner history

--- a/docs/agents/skills/sudoku-tester.md
+++ b/docs/agents/skills/sudoku-tester.md
@@ -243,12 +243,45 @@ Severity levels:
 - 🟡 **Minor**: UX issue, inconsistency, or edge case
 - 🔵 **Cosmetic**: Typos, formatting, display issues
 
+## Creating GitHub Issues for Bugs
+
+For every bug found (severity 🔴🟠🟡), create a GitHub issue:
+
+```bash
+cd /home/claw1/repos/sudoku-solver
+gh issue create --repo sudoku-solver-bot/sudoku-solver \
+  --title "bug: [Short description]" \
+  --body "## Severity: [🔴 Critical / 🟠 Major / 🟡 Minor]
+
+**Endpoint:** \`POST /api/v1/hint\`
+**Input:** \`{\"puzzle\":\"007239061...\"}\`
+**Expected:** [what should happen]
+**Actual:** [what actually happens]
+
+## Steps to Reproduce
+1. ...
+2. ...
+
+## Impact
+[Why this matters]
+"
+```
+
+**Rules for issues:**
+- Title prefix: `bug:` (not `feat:` or `docs:`)
+- Include severity emoji in the body
+- Always include reproducible steps
+- One issue per bug
+- Don't create issues for 🟢 cosmetic/🔵 minor typos unless they're misleading
+- After creating issues, list them in the test results summary
+
 ## Rules
 
-1. **Read-only** — only probe, never modify
-2. Test ALL 20 tutorials every run
-3. Test ALL difficulty levels for generate
-4. Always validate solve results (correct sudoku solution)
-5. Report concrete reproducible bugs, not vague concerns
-6. Compare local vs remote at least once per run
-7. Report findings to the planner by updating the roadmap or creating a findings file
+1. **Read-only** — only probe, never modify code
+2. **Create GitHub issues** for every 🔴🟠🟡 bug found
+3. Test ALL 20 tutorials every run
+4. Test ALL difficulty levels for generate
+5. Always validate solve results (correct sudoku solution)
+6. Report concrete reproducible bugs, not vague concerns
+7. Compare local vs remote at least once per run
+8. Write findings to `memory/sudoku-test-results-YYYY-MM-DD.md`

--- a/docs/agents/skills/sudoku-tester.md
+++ b/docs/agents/skills/sudoku-tester.md
@@ -1,0 +1,254 @@
+---
+name: sudoku-tester
+description: Actively tests all features on the deployed sudoku-solver server. Exercises every API endpoint, validates tutorial content against puzzles, checks for inconsistencies, and reports bugs to the planner. Use when asked to test the sudoku app, check for bugs, validate tutorials, or QA the deployed server.
+---
+
+# Sudoku Tester
+
+Active QA agent that exercises the live sudoku-solver server and finds bugs.
+
+## What This Agent Does
+
+- Tests every API endpoint with real inputs
+- Validates all 20 tutorials (description vs puzzle vs steps)
+- Checks solve results for correctness
+- Tests edge cases (invalid input, empty puzzles, malformed data)
+- Compares local vs remote server responses
+- Reports all findings as structured bug reports for the planner
+
+## What This Agent Does NOT Do
+
+- Never modifies code, config, or files
+- Never creates issues or PRs
+- Never restarts services
+
+## Server Endpoints
+
+- **Local:** `http://localhost:25321`
+- **Remote:** `https://sudoku-solver-r5y8.onrender.com`
+
+### API Surface
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/health` | GET | Health check (JVM, memory, uptime) |
+| `/api/v1/solve` | POST | Solve a puzzle (body: `{"puzzle":"..."}`) |
+| `/api/v1/validate` | POST | Validate puzzle (body: `{"puzzle":"..."}`) |
+| `/api/v1/hint` | POST | Get hint (body: `{"puzzle":"..."}`) |
+| `/api/v1/generate` | POST | Generate puzzle (body: `{"difficulty":"easy\|medium\|hard\|expert\|master"}`) |
+| `/api/v1/candidates` | POST | Get candidate sets (body: `{"puzzle":"..."}`) |
+| `/api/v1/step-by-step` | POST | Step-by-step solve (body: `{"puzzle":"..."}`, use `0` for empty) |
+| `/api/v1/daily` | GET | Today's daily challenge |
+| `/api/v1/tutorials` | GET | List all tutorials |
+| `/api/v1/tutorials/{id}` | GET | Get tutorial details |
+| `/api/v1/dashboard/report` | POST | Dashboard report (body: `{"studentId":"..."}`) |
+| `/api/v1/progress` | POST | Progress tracking (body: `{"userId":"..."}`) |
+| `/api/v1/generate/difficulty/{level}` | GET | Get difficulty details |
+
+**Puzzle format:** 81-character string, `0` for empty cells (some endpoints also accept `.`).
+
+## Test Suite
+
+### 1. Health Check
+```bash
+curl -sf http://localhost:25321/api/health | python3 -m json.tool
+```
+- Check: `status` == "OK", `uptime` is reasonable, `memory.heapUsedPercent` < 90%
+
+### 2. Generate + Solve Roundtrip
+```bash
+# Generate puzzles at each difficulty
+for diff in easy medium hard expert master; do
+  PUZZLE=$(curl -sf -X POST http://localhost:25321/api/v1/generate \
+    -H "Content-Type: application/json" \
+    -d "{\"difficulty\":\"$diff\"}" | python3 -c "import json,sys; print(json.load(sys.stdin)['puzzle'])")
+  
+  # Solve the generated puzzle
+  RESULT=$(curl -sf -X POST http://localhost:25321/api/v1/solve \
+    -H "Content-Type: application/json" \
+    -d "{\"puzzle\":\"$PUZZLE\"}")
+  
+  SOLVED=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('solved',False))")
+  SOLUTION=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('solution',''))")
+  
+  # Validate solution
+  # - All 81 chars are digits 1-9
+  # - Each row has digits 1-9
+  # - Each column has digits 1-9  
+  # - Each 3x3 box has digits 1-9
+  echo "$diff: solved=$SOLVED len=${#SOLUTION}"
+done
+```
+
+### 3. Validate Correctness
+```bash
+# Generate a puzzle, solve it, then validate the solution
+PUZZLE=$(curl -sf -X POST http://localhost:25321/api/v1/generate \
+  -H "Content-Type: application/json" -d '{"difficulty":"easy"}' | python3 -c "import json,sys; print(json.load(sys.stdin)['puzzle'])")
+
+SOLUTION=$(curl -sf -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d "{\"puzzle\":\"$PUZZLE\"}" | python3 -c "import json,sys; print(json.load(sys.stdin)['solution'])")
+
+# Validate the solution
+curl -sf -X POST http://localhost:25321/api/v1/validate \
+  -H "Content-Type: application/json" -d "{\"puzzle\":\"$SOLUTION\"}"
+# Should be valid with uniqueSolution: true
+```
+
+### 4. Hint Quality
+```bash
+PUZZLE=$(curl -sf -X POST http://localhost:25321/api/v1/generate \
+  -H "Content-Type: application/json" -d '{"difficulty":"medium"}' | python3 -c "import json,sys; print(json.load(sys.stdin)['puzzle'])")
+
+PUZZLE0=$(echo "$PUZZLE" | tr '.' '0')
+
+curl -sf -X POST http://localhost:25321/api/v1/hint \
+  -H "Content-Type: application/json" -d "{\"puzzle\":\"$PUZZLE0\"}"
+```
+- Check: `technique` is not null/empty, `explanation` is meaningful
+- Bug: hint returning generic "Scanning" when specific technique applies
+
+### 5. Tutorial Validation (CRITICAL)
+```bash
+# Get all tutorials
+TUTORIALS=$(curl -sf http://localhost:25321/api/v1/tutorials)
+
+# For each tutorial, get full details and validate
+for ID in naked-single hidden-single naked-pair hidden-pair pointing-pair \
+          box-line-reduction naked-triple hidden-triple x-wing swordfish \
+          xy-wing xyz-wing unique-rectangle simple-coloring w-wing \
+          als-xz franken-fish mutant-fish death-blossom forcing-chains; do
+  
+  TUTORIAL=$(curl -sf http://localhost:25321/api/v1/tutorials/$ID)
+  
+  # Extract and check:
+  # - title and description match the technique
+  # - examplePuzzle is a valid 81-char puzzle (if present)
+  # - examplePuzzle actually demonstrates the technique
+  # - steps have meaningful text (not "?" or empty)
+  # - highlighted cells are valid (0-80)
+  # - the tutorial's technique can actually solve a step in the puzzle
+  echo "$ID: $(echo "$TUTORIAL" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+puzzle=d.get('examplePuzzle','')
+steps=d.get('steps',[])
+issues=[]
+if not puzzle:
+    issues.append('MISSING_PUZZLE')
+elif len(puzzle)!=81:
+    issues.append(f'BAD_PUZZLE_LEN:{len(puzzle)}')
+elif puzzle.count('.')+puzzle.count('0')>50:
+    issues.append('TOO_EMPTY')
+for i,s in enumerate(steps):
+    t=s.get('text','')
+    if not t or t=='?':
+        issues.append(f'EMPTY_STEP:{i+1}')
+    cells=s.get('cells',[])
+    for c in cells:
+        if c<0 or c>80:
+            issues.append(f'BAD_CELL:{c}_step{i+1}')
+print(f'issues={issues}' if issues else 'OK')
+")"
+done
+```
+
+### 6. Tutorial Puzzle Consistency
+For each tutorial:
+1. Get the `examplePuzzle`
+2. Solve it with `/api/v1/solve`
+3. Get candidates with `/api/v1/candidates`
+4. Get hints with `/api/v1/hint`
+5. Verify the hinted technique matches the tutorial's teaching technique
+6. Verify the highlighted cells in tutorial steps actually demonstrate what's described
+
+### 7. Edge Cases
+```bash
+# Empty puzzle
+curl -s -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d '{"puzzle":""}' 2>&1
+
+# Too short
+curl -s -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d '{"puzzle":"12345"}' 2>&1
+
+# Invalid characters
+curl -s -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d '{"puzzle":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}' 2>&1
+
+# Already solved (all 81 filled)
+curl -s -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d '{"puzzle":"534678912672195348198342567859761423426853791713924856961537284287419635345286179"}' 2>&1
+
+# Unsolvable puzzle
+curl -s -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d '{"puzzle":"111111111111111111111111111111111111111111111111111111111111111111111111111111111"}' 2>&1
+```
+
+### 8. Daily Challenge
+```bash
+# Get today's daily
+curl -sf http://localhost:25321/api/v1/daily | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(f'Date: {d.get(\"date\")}')
+print(f'Puzzle: {d.get(\"puzzle\",\"NONE\")} (len={len(d.get(\"puzzle\",\"\"))})')
+print(f'Difficulty: {d.get(\"difficulty\")}')
+puzzle=d.get('puzzle','')
+if len(puzzle)==81:
+    print('Valid length')
+else:
+    print(f'BAD LENGTH: {len(puzzle)}')
+"
+```
+
+### 9. Local vs Remote Comparison
+```bash
+# Generate same puzzle on both, compare solve results
+PUZZLE=$(curl -sf -X POST http://localhost:25321/api/v1/generate \
+  -H "Content-Type: application/json" -d '{"difficulty":"easy"}' | python3 -c "import json,sys; print(json.load(sys.stdin)['puzzle'])")
+
+LOCAL=$(curl -sf -X POST http://localhost:25321/api/v1/solve \
+  -H "Content-Type: application/json" -d "{\"puzzle\":\"$PUZZLE\"}")
+
+REMOTE=$(curl -sf -X POST https://sudoku-solver-r5y8.onrender.com/api/v1/solve \
+  -H "Content-Type: application/json" -d "{\"puzzle\":\"$PUZZLE\"}")
+
+# Compare solutions
+```
+
+## Bug Report Format
+
+When you find an issue, report it in this format:
+
+```markdown
+### 🐛 [Severity] Brief Description
+
+**Endpoint:** `POST /api/v1/hint`
+**Input:** `{"puzzle":"007239061..."}`
+**Expected:** Technique "Hidden Single" with specific cell
+**Actual:** Generic "Scanning" hint with no cell
+
+**Steps to Reproduce:**
+1. Generate a medium puzzle
+2. Request hint
+3. Observe generic response
+
+**Impact:** Users don't get useful hints for medium+ puzzles
+```
+
+Severity levels:
+- 🔴 **Critical**: Feature completely broken, returns errors
+- 🟠 **Major**: Feature works but gives wrong/misleading results
+- 🟡 **Minor**: UX issue, inconsistency, or edge case
+- 🔵 **Cosmetic**: Typos, formatting, display issues
+
+## Rules
+
+1. **Read-only** — only probe, never modify
+2. Test ALL 20 tutorials every run
+3. Test ALL difficulty levels for generate
+4. Always validate solve results (correct sudoku solution)
+5. Report concrete reproducible bugs, not vague concerns
+6. Compare local vs remote at least once per run
+7. Report findings to the planner by updating the roadmap or creating a findings file


### PR DESCRIPTION
Closes #219

## Changes
- **Tester skill**: Now creates GitHub issues (`bug:` prefix) for every bug found
- **Planner skill**: Now creates GitHub issues (`plan:` prefix + label) for implementation plans

## Why
Bugs and plans should be visible on GitHub for all contributors, not just in local memory.

## Files Changed
- `docs/agents/skills/sudoku-tester.md` — Added GitHub issue creation section
- `docs/agents/skills/sudoku-planner.md` — Added GitHub plan creation section