### PR TITLE
fix: verify unique solutions during puzzle generation (Closes #255)

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/PuzzleGenerator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/PuzzleGenerator.kt
@@ -91,10 +91,14 @@ object PuzzleGenerator {
 
     /**
      * Remove cells from a solved board to create a puzzle.
+     * Verifies uniqueness after each removal — if removing a cell
+     * creates multiple solutions, the cell is restored and another
+     * cell is tried instead.
      */
     private fun removeCells(board: Board, count: Int, random: Random): Board {
         val puzzle = board.copy()
         val positions = (0..80).shuffled(random)
+        val wildcardPattern = (1 shl 9) - 1
 
         var removed = 0
         for (pos in positions) {
@@ -104,16 +108,22 @@ object PuzzleGenerator {
             val col = pos % 9
             val coord = Coord(row, col)
 
-            // Temporarily remove the value
+            // Skip already-empty cells
             val originalValue = puzzle.value(coord)
             if (originalValue == 0) continue
 
-            // Clear the cell (set to all candidates)
-            puzzle.candidatePatterns[pos] = (1..9).fold(0) { acc, v -> acc or Board.masks[v - 1] }
+            // Save original pattern for restoration
+            val originalPattern = puzzle.candidatePatterns[pos]
 
-            // Check if puzzle still has unique solution
-            // For performance, we skip this check for most puzzles
-            // In a production system, you would verify uniqueness here
+            // Clear the cell (set to all candidates)
+            puzzle.candidatePatterns[pos] = wildcardPattern
+
+            // Verify puzzle still has exactly one solution
+            if (!PuzzleValidator.hasUniqueSolution(puzzle)) {
+                // Removing this cell broke uniqueness — restore it
+                puzzle.candidatePatterns[pos] = originalPattern
+                continue
+            }
 
             removed++
         }

--- a/kotlin/src/test/java/will/sudoku/solver/GeneratorUniquenessTest.kt
+++ b/kotlin/src/test/java/will/sudoku/solver/GeneratorUniquenessTest.kt
@@ -1,0 +1,61 @@
+package will.sudoku.solver
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Verify that PuzzleGenerator produces puzzles with unique solutions
+ * across all difficulty levels.
+ */
+class GeneratorUniquenessTest {
+
+    @Test
+    fun `easy puzzle has unique solution`() {
+        repeat(2) {
+            val puzzle = PuzzleGenerator.generate(DifficultyRater.Level.EASY)
+            assertThat(PuzzleValidator.hasUniqueSolution(puzzle))
+                .withFailMessage("Easy puzzle should have unique solution")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `medium puzzle has unique solution`() {
+        repeat(2) {
+            val puzzle = PuzzleGenerator.generate(DifficultyRater.Level.MEDIUM)
+            assertThat(PuzzleValidator.hasUniqueSolution(puzzle))
+                .withFailMessage("Medium puzzle should have unique solution")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `hard puzzle has unique solution`() {
+        repeat(2) {
+            val puzzle = PuzzleGenerator.generate(DifficultyRater.Level.HARD)
+            assertThat(PuzzleValidator.hasUniqueSolution(puzzle))
+                .withFailMessage("Hard puzzle should have unique solution")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `expert puzzle has unique solution`() {
+        repeat(2) {
+            val puzzle = PuzzleGenerator.generate(DifficultyRater.Level.EXPERT)
+            assertThat(PuzzleValidator.hasUniqueSolution(puzzle))
+                .withFailMessage("Expert puzzle should have unique solution")
+                .isTrue()
+        }
+    }
+
+    @Test
+    fun `master puzzle has unique solution`() {
+        repeat(2) {
+            val puzzle = PuzzleGenerator.generate(DifficultyRater.Level.MASTER)
+            assertThat(PuzzleValidator.hasUniqueSolution(puzzle))
+                .withFailMessage("Master puzzle should have unique solution")
+                .isTrue()
+        }
+    }
+}


### PR DESCRIPTION
## What

The puzzle generator was blindly removing cells from a solved board without checking if the resulting puzzle still had a unique solution. This caused **100% failure rate** for hard/expert/master puzzles (all produced puzzles with multiple solutions).

## Fix

After each cell removal, call PuzzleValidator.hasUniqueSolution() to verify the puzzle still has exactly one solution. If removal breaks uniqueness, the cell is restored and a different cell is tried.

## Changes

- **PuzzleGenerator.kt**: Modified removeCells() to verify uniqueness after each cell removal
- **GeneratorUniquenessTest.kt**: New test class verifying all 5 difficulty levels produce unique-solution puzzles

## Testing

All tests pass. All difficulty levels verified. Known multi-solution puzzle correctly detected.
Closes #255