### PR TITLE
fix: add fallback solver for multi-solution puzzles (Closes #256)

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/Solver.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/Solver.kt
@@ -50,6 +50,10 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
     /**
      * Solves the given Sudoku puzzle with a listener for observing the process.
      *
+     * If the initial solve fails and uniqueness-assuming eliminators are in use,
+     * automatically falls back to basic eliminators to handle puzzles with
+     * multiple solutions (see #256).
+     *
      * @param board The puzzle board to solve
      * @param listener Listener to receive callbacks during solving
      * @return The solved board, or null if no solution exists
@@ -62,7 +66,17 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         
         listener.onPropagationPassStarted()
         
-        val result = solveInternal(board, 0, listener)
+        var result = solveInternal(board, 0, listener)
+        
+        // Fallback: if the main solver fails and we're using uniqueness-assuming
+        // eliminators (like UniqueRectangles), retry with basic eliminators.
+        // Uniqueness techniques can eliminate valid candidates from puzzles
+        // that have multiple solutions, causing false negatives.
+        if (result == null && config.usesUniquenessTechniques()) {
+            val fallbackConfig = SolverConfig.basic()
+            val fallbackSolver = Solver(fallbackConfig)
+            result = fallbackSolver.solve(board.copy(), NoOpListener)
+        }
         
         // Notify completion
         val timeNanos = System.nanoTime() - startTime

--- a/kotlin/src/main/java/will/sudoku/solver/SolverConfig.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/SolverConfig.kt
@@ -97,6 +97,14 @@ data class SolverConfig(
     }
 
     /**
+     * Returns true if any configured eliminator assumes the puzzle has a unique solution.
+     * These techniques can eliminate valid candidates from puzzles with multiple solutions.
+     */
+    fun usesUniquenessTechniques(): Boolean {
+        return eliminators.any { it is UniqueRectanglesCandidateEliminator }
+    }
+
+    /**
      * Difficulty levels for solver configuration.
      */
     enum class DifficultyLevel {

--- a/kotlin/src/test/java/will/sudoku/solver/SolverTest.kt
+++ b/kotlin/src/test/java/will/sudoku/solver/SolverTest.kt
@@ -1,6 +1,7 @@
 package will.sudoku.solver
 
 import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -21,6 +22,31 @@ class SolverTest {
     fun test(boardName: String, board: Board, expected: Board) {
         val solved = Solver().solve(board)
         Assertions.assertThat(solved).isEqualTo(expected)
+    }
+
+    /**
+     * Regression test for #256: Solver should find a solution for puzzles
+     * with multiple solutions, not return null. The fallback to basic
+     * eliminators (without uniqueness-assuming techniques) handles this.
+     */
+    @Test
+    fun `should solve puzzle with multiple solutions`() {
+        // Puzzle from #256 — known to have 3 valid solutions
+        val puzzle = "438.....9..16....3...73.........9.6.8..1..3...76.2....1...4279692...6.3.....17..."
+        val board = BoardReader.readBoard(puzzle)
+        val solved = Solver().solve(board)
+
+        Assertions.assertThat(solved)
+            .`as`("Solver should find a solution for a multi-solution puzzle (fallback)")
+            .isNotNull
+
+        Assertions.assertThat(solved!!.isSolved())
+            .`as`("Result should be a fully solved board")
+            .isTrue
+
+        Assertions.assertThat(solved.isValid())
+            .`as`("Result should be a valid board")
+            .isTrue
     }
 
     @ExperimentalPathApi


### PR DESCRIPTION
## Problem
The solver returns "No solution found" for puzzles with multiple solutions because the default eliminator configuration includes `UniqueRectanglesCandidateEliminator`, which assumes the puzzle has a unique solution and can eliminate valid candidates from multi-solution puzzles.

## Fix
When the main solver fails and uniqueness-assuming techniques are in use, automatically fall back to basic eliminators (simple elimination + exclusion) that work correctly on multi-solution puzzles.

### Changes
- **SolverConfig**: Added `usesUniquenessTechniques()` to detect when uniqueness-assuming eliminators are configured
- **Solver**: Modified `solve()` to retry with `SolverConfig.basic()` when the initial solve returns null and uniqueness techniques are present
- **SolverTest**: Added regression test using the example puzzle from #256

## Testing
- All existing tests pass
- New regression test verifies the multi-solution puzzle from #256 now solves successfully
- Frontend lint passes
- Frontend build succeeds