### PR TITLE
fix: add Master difficulty to GET /generate/difficulty/{level} route (Closes #267, Closes #260)

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/DifficultyLevel.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/DifficultyLevel.kt
@@ -12,7 +12,8 @@ enum class DifficultyLevel(
     EASY("Easy", "8-9 years", 36, 45),
     MEDIUM("Medium", "10-11 years", 30, 35),
     HARD("Hard", "12-13 years", 26, 29),
-    EXPERT("Expert", "14+ years", 22, 25);
+    EXPERT("Expert", "14+ years", 22, 25),
+    MASTER("Master", "Expert+", 17, 21);
     
     companion object {
         fun forAge(age: Int): DifficultyLevel {

--- a/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
@@ -36,6 +36,7 @@ fun Route.difficultyRoutes() {
             DifficultyLevel.MEDIUM -> DifficultyRater.Level.MEDIUM
             DifficultyLevel.HARD -> DifficultyRater.Level.HARD
             DifficultyLevel.EXPERT -> DifficultyRater.Level.EXPERT
+            DifficultyLevel.MASTER -> DifficultyRater.Level.MASTER
         }
         
         val board = PuzzleGenerator.generate(raterLevel)
@@ -78,6 +79,7 @@ fun Route.difficultyRoutes() {
             DifficultyLevel.MEDIUM -> DifficultyRater.Level.MEDIUM
             DifficultyLevel.HARD -> DifficultyRater.Level.HARD
             DifficultyLevel.EXPERT -> DifficultyRater.Level.EXPERT
+            DifficultyLevel.MASTER -> DifficultyRater.Level.MASTER
         }
         
         val board = PuzzleGenerator.generate(raterLevel)


### PR DESCRIPTION
Closes #267, Closes #260

## Changes
- Added `MASTER` to `DifficultyLevel` enum with `Expert+` target age and 17-21 clue range
- Added `MASTER` case to both when-expressions in `DifficultyRoutes.kt` (POST and GET routes)
- Fixes `GET /api/v1/generate/difficulty/master` returning 400 "Invalid difficulty level: master"

## Root Cause
Two separate enum systems exist: `DifficultyLevel` (age-based, used in difficulty routes) and `DifficultyRater.Level` (solver-based, used in generate routes). `DifficultyRater.Level` had MASTER, but `DifficultyLevel` did not. The GET route at `/generate/difficulty/{level}` uses `DifficultyLevel.valueOf()` for parsing, which rejected "master".

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend lint passes (`npm run lint:ci`)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)