### PR TITLE
fix: update GitHub Actions in codeql and detekt workflows (Closes #270)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -27,7 +27,7 @@ on:
 env:
   # Release tag associated with version of Detekt to be installed
   # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
-  DETEKT_RELEASE_TAG: v1.15.0
+  DETEKT_RELEASE_TAG: v1.23.8
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -40,7 +40,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Gets the download URL associated with the $DETEKT_RELEASE_TAG
     - name: Get Detekt download URL
@@ -62,7 +62,7 @@ jobs:
           }
         ' | \
         jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
+        echo "download_url=$DETEKT_DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
 
     # Sets up the detekt cli
     - name: Setup Detekt
@@ -96,7 +96,7 @@ jobs:
         )" > ${{ github.workspace }}/detekt.sarif.json
 
     # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v1
+    - uses: github/codeql-action/upload-sarif@v3
       with:
         # Path to SARIF file relative to the root of the repository
         sarif_file: ${{ github.workspace }}/detekt.sarif.json


### PR DESCRIPTION
Closes #270

## Changes
- `codeql-analysis.yml`: `actions/checkout@v2`→`v4`, all `github/codeql-action@v1`→`v3`
- `detekt-analysis.yml`: `actions/checkout@v2`→`v4`, `upload-sarif@v1`→`v3`
- Detekt release tag `v1.15.0`→`v1.23.8` (latest stable)
- Fix deprecated `::set-output` → `$GITHUB_OUTPUT`

## Testing
- [x] YAML syntax is valid
- [ ] CodeQL workflow runs without errors
- [ ] Detekt workflow runs and uploads SARIF results