### PR TITLE
fix: replace incompatible JsonEncoder with PatternLayoutEncoder

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -26,9 +26,6 @@ dependencies {
     
     // Logging
     implementation("ch.qos.logback:logback-classic:1.4.14")
-    implementation("ch.qos.logback.contrib:logback-json-classic:0.1.5")
-    implementation("ch.qos.logback.contrib:logback-jackson:0.1.5")
-    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
     
     // Core solver module
     implementation(project(":kotlin"))

--- a/web/src/main/resources/logback.xml
+++ b/web/src/main/resources/logback.xml
@@ -1,11 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.contrib.json.classic.JsonEncoder">
-            <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
-                <prettyPrint>false</prettyPrint>
-            </jsonFormatter>
-            <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
-            <appendLineSeparator>true</appendLineSeparator>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -15,7 +11,7 @@
 
     <!-- Set Ktor logging to INFO -->
     <logger name="io.ktor" level="INFO"/>
-    
+
     <!-- Set application logging to DEBUG for development -->
     <logger name="will.sudoku" level="DEBUG"/>
 </configuration>


### PR DESCRIPTION
Closes #284

## Changes
- Replaced `ch.qos.logback.contrib.json.classic.JsonEncoder` with built-in `PatternLayoutEncoder` in `logback.xml`
- Removed 3 incompatible dependencies from `web/build.gradle.kts`:
  - `logback-json-classic:0.1.5` (built for logback 1.2.x, incompatible with 1.4.x)
  - `logback-jackson:0.1.5`
  - `logstash-logback-encoder:7.4`

## Root Cause
`logback-json-classic:0.1.5` was compiled against logback-classic 1.2.x but the project uses logback-classic 1.4.14 (SLF4J 2.0.x). This version mismatch causes `ClassNotFoundException` at runtime, crashing the server every ~6 hours.

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)
- [x] No ClassNotFoundException during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)