### PR TITLE
fix: use direct download URL for Detekt CLI in CI

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -42,17 +42,20 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Sets up the detekt cli using direct download URL
+    # Sets up the detekt cli by downloading the all-in-one JAR and creating a wrapper script
     - name: Setup Detekt
       run: |
         dest=$( mktemp -d )
+        DETEKT_VERSION="${DETEKT_RELEASE_TAG#v}"
         curl --request GET \
-          --url https://github.com/detekt/detekt/releases/download/${{ env.DETEKT_RELEASE_TAG }}/detekt \
+          --url "https://github.com/detekt/detekt/releases/download/${DETEKT_RELEASE_TAG}/detekt-cli-${DETEKT_VERSION}-all.jar" \
           --silent \
           --location \
-          --output $dest/detekt
-        chmod a+x $dest/detekt
-        echo $dest >> $GITHUB_PATH
+          --output "$dest/detekt-cli-all.jar"
+        echo '#!/bin/bash' > "$dest/detekt"
+        echo "java -jar \"$dest/detekt-cli-all.jar\" \"\$@\"" >> "$dest/detekt"
+        chmod a+x "$dest/detekt"
+        echo "$dest" >> "$GITHUB_PATH"
 
     # Performs static analysis using Detekt
     - name: Run Detekt

--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -42,34 +42,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
-    - name: Get Detekt download URL
-      id: detekt_info
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        DETEKT_DOWNLOAD_URL=$( gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
-          query getReleaseAssetDownloadUrl($tagName: String!) {
-            repository(name: "detekt", owner: "detekt") {
-              release(tagName: $tagName) {
-                releaseAssets(name: "detekt", first: 1) {
-                  nodes {
-                    downloadUrl
-                  }
-                }
-              }
-            }
-          }
-        ' | \
-        jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
-        echo "download_url=$DETEKT_DOWNLOAD_URL" >> "$GITHUB_OUTPUT"
-
-    # Sets up the detekt cli
+    # Sets up the detekt cli using direct download URL
     - name: Setup Detekt
       run: |
         dest=$( mktemp -d )
         curl --request GET \
-          --url ${{ steps.detekt_info.outputs.download_url }} \
+          --url https://github.com/detekt/detekt/releases/download/${{ env.DETEKT_RELEASE_TAG }}/detekt \
           --silent \
           --location \
           --output $dest/detekt


### PR DESCRIPTION
Fixes the failing Detekt scan CI check that affects all PRs.

## Changes
- Replaced the GraphQL-based Detekt download URL resolution with a direct download URL
- The GraphQL query was returning `null`, causing `curl` to fail with exit code 6
- Direct URL: `https://github.com/detekt/detekt/releases/download/v1.23.8/detekt`

## Root Cause
The original workflow used a GraphQL query to find the download URL for the Detekt CLI binary from the `detekt/detekt` repo. This query was returning `null` for the `releaseAssets.nodes[0].downloadUrl` field, likely due to changes in the GitHub GraphQL API or the Detekt release asset naming.

## Testing
- [x] YAML syntax is valid
- [x] Direct URL pattern matches standard GitHub release download format
- [ ] CI Detekt scan should now pass (will verify after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)