### PR TITLE
fix: step-by-step solver shows technique names instead of Guess/Backtrack

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/Board.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/Board.kt
@@ -212,5 +212,12 @@ class Board private constructor(val candidatePatterns: IntArray) {
             .minByOrNull { candidatePattern(it).countOneBits() }
     }
 
+    /**
+     * Count total candidates across all cells. Used for before/after comparison
+     * when tracking eliminator effects.
+     */
+    fun countTotalCandidates(): Int {
+        return Coord.all.sumOf { candidatePattern(it).countOneBits() }
+    }
 
 }

--- a/kotlin/src/main/java/will/sudoku/solver/CandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/CandidateEliminator.kt
@@ -2,5 +2,11 @@ package will.sudoku.solver
 
 interface CandidateEliminator {
 
+    /**
+     * Human-readable display name for this technique (e.g., "Naked Single", "X-Wing").
+     * Default derives from the class simple name. Override for better display names.
+     */
+    val displayName: String get() = javaClass.simpleName.removeSuffix("CandidateEliminator")
+
     fun eliminate(board: Board): Boolean
 }

--- a/kotlin/src/main/java/will/sudoku/solver/ExclusionCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/ExclusionCandidateEliminator.kt
@@ -5,6 +5,7 @@ import will.sudoku.solver.Board.Companion.masks
 // This simple eliminator simply scan all confirmed values
 // and the remove candidates of the same group
 class ExclusionCandidateEliminator(var shortCircuitThreshold: Int) : CandidateEliminator {
+    override val displayName = "Hidden Single"
 
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false

--- a/kotlin/src/main/java/will/sudoku/solver/GroupCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/GroupCandidateEliminator.kt
@@ -1,6 +1,7 @@
 package will.sudoku.solver
 
 class GroupCandidateEliminator : CandidateEliminator {
+    override val displayName = "Naked Subset"
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false
         var stable: Boolean

--- a/kotlin/src/main/java/will/sudoku/solver/HiddenSubsetCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/HiddenSubsetCandidateEliminator.kt
@@ -24,6 +24,7 @@ package will.sudoku.solver
  * - Hidden quads (4 candidates in 4 cells)
  */
 class HiddenSubsetCandidateEliminator : CandidateEliminator {
+    override val displayName = "Hidden Subset"
 
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false

--- a/kotlin/src/main/java/will/sudoku/solver/SimpleCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/SimpleCandidateEliminator.kt
@@ -1,6 +1,7 @@
 package will.sudoku.solver
 
 class SimpleCandidateEliminator : CandidateEliminator {
+    override val displayName = "Simple Elimination"
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false
         var stable: Boolean

--- a/kotlin/src/main/java/will/sudoku/solver/Solver.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/Solver.kt
@@ -66,6 +66,8 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         
         listener.onPropagationPassStarted()
         
+        // Save original board for fallback (solveInternal may mutate its input)
+        val originalBoard = board.copy()
         var result = solveInternal(board, 0, listener)
         
         // Fallback: if the main solver fails and we're using uniqueness-assuming
@@ -75,7 +77,7 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         if (result == null && config.usesUniquenessTechniques()) {
             val fallbackConfig = SolverConfig.basic()
             val fallbackSolver = Solver(fallbackConfig)
-            result = fallbackSolver.solve(board.copy(), NoOpListener)
+            result = fallbackSolver.solve(originalBoard, NoOpListener)
         }
         
         // Notify completion
@@ -119,10 +121,33 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         if (!board.isValid()) return null
         if (board.isSolved()) return board
 
+        // Phase 1: Constraint propagation — apply all eliminators iteratively until stable
+        // This discovers technique-based deductions (Naked Singles, Hidden Singles, etc.)
+        // before falling back to backtracking. Each technique application is recorded.
+        var anyProgress = true
+        while (anyProgress) {
+            anyProgress = false
+            for (eliminator in config.eliminators) {
+                val candidatesBefore = board.countTotalCandidates()
+                val changed = eliminator.eliminate(board)
+                if (changed) {
+                    val eliminated = candidatesBefore - board.countTotalCandidates()
+                    if (eliminated > 0) {
+                        listener.onEliminatorApplied(eliminator.displayName, eliminated)
+                    }
+                    anyProgress = true
+                }
+            }
+        }
+
+        if (!board.isValid()) return null
+        if (board.isSolved()) return board
+
+        // Phase 2: Pick unresolved cell with fewest candidates (MRV heuristic)
         val unresolvedCoord = board.unresolvedCoord() ?: return null
         val candidates = board.candidateValues(unresolvedCoord).toList()
-        
-        // If this is a guess point (more than one candidate), notify listener
+
+        // If more than one candidate, this is a guess point — notify listener
         if (candidates.size > 1) {
             listener.onGuessMade(unresolvedCoord, candidates.first(), candidates.size)
         }
@@ -130,25 +155,20 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         for (candidateValue in candidates) {
             val newBoard = board.copy()
             newBoard.markValue(unresolvedCoord, candidateValue)
-            
-            // Notify listener about cell fill
+
+            // Record cell fill with technique-aware explanation
             val explanation = if (candidates.size == 1) {
-                "Only candidate"
+                "Naked Single at (${unresolvedCoord.row + 1}, ${unresolvedCoord.col + 1}) — only candidate is $candidateValue"
             } else {
-                "Guess (try $candidateValue among ${candidates.size} candidates)"
+                "Guess (try $candidateValue among ${candidates.size} candidates) at (${unresolvedCoord.row + 1}, ${unresolvedCoord.col + 1})"
             }
             listener.onCellFilled(unresolvedCoord, candidateValue, explanation)
-
-            // Apply constraint propagation
-            for (eliminator in config.eliminators) {
-                eliminator.eliminate(newBoard)
-            }
 
             val result = solveInternal(newBoard, depth + 1, listener)
             if (result != null) {
                 return result
             }
-            
+
             // Backtrack
             listener.onBacktracking()
         }

--- a/kotlin/src/main/java/will/sudoku/solver/SolvingStep.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/SolvingStep.kt
@@ -81,6 +81,24 @@ data class SolvingStep(
                 explanation = explanation
             )
         }
+
+        /**
+         * Create a step for a technique application (eliminator ran and eliminated candidates).
+         */
+        fun techniqueApplied(
+            stepNumber: Int,
+            techniqueName: String,
+            eliminations: Int,
+            explanation: String
+        ): SolvingStep {
+            return SolvingStep(
+                stepNumber = stepNumber,
+                stepType = StepType.fromTechniqueName(techniqueName),
+                affectedCells = emptyList(),
+                values = emptySet(),
+                explanation = explanation
+            )
+        }
     }
 
     /**

--- a/kotlin/src/main/java/will/sudoku/solver/StepRecorder.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/StepRecorder.kt
@@ -79,9 +79,14 @@ class StepRecorder : SolvingListener {
     }
     
     override fun onEliminatorApplied(name: String, eliminations: Int) {
-        // Optionally record eliminator applications as steps
-        // For now, we'll skip this to keep step count manageable
-        // Could be enabled via configuration flag
+        stepNumber++
+        val stepType = StepType.fromTechniqueName(name)
+        _steps.add(SolvingStep.techniqueApplied(
+            stepNumber = stepNumber,
+            techniqueName = name,
+            eliminations = eliminations,
+            explanation = "$name: $eliminations candidate(s) eliminated"
+        ))
     }
     
     override fun onSolveComplete(solved: Boolean, timeNanos: Long, backtracks: Int) {

--- a/kotlin/src/main/java/will/sudoku/solver/StepType.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/StepType.kt
@@ -21,8 +21,24 @@ enum class StepType(val displayName: String, val description: String) {
     GUESS_MADE("Guess Made", "Made a guess (backtracking required)"),
     BACKTRACK("Backtrack", "Previous guess was wrong, trying another option"),
 
+    // Generic technique application (when specific technique type is unknown)
+    TECHNIQUE_APPLIED("Technique Applied", "A solving technique was applied"),
+
     // Status
     PUZZLE_SOLVED("Puzzle Solved", "The puzzle has been completely solved"),
     NO_SOLUTION("No Solution", "The puzzle has no valid solution"),
     AMBIGUOUS("Ambiguous", "Puzzle has multiple solutions (not unique)");
+
+    companion object {
+        /**
+         * Try to find a matching StepType for an eliminator display name.
+         * Falls back to TECHNIQUE_APPLIED if no match.
+         */
+        fun fromTechniqueName(name: String): StepType {
+            return entries.firstOrNull {
+                it.displayName.equals(name, ignoreCase = true) ||
+                it.name.replace("_", " ").equals(name, ignoreCase = true)
+            } ?: TECHNIQUE_APPLIED
+        }
+    }
 }


### PR DESCRIPTION
Closes #287, closes #288

## Problem
The step-by-step solver (`POST /api/v1/step-by-step`) only showed "Guess" and "Backtrack" steps instead of technique-based explanations. This made the feature useless for learning.

## Root Cause
1. `Solver.solveInternal` applied eliminators but never called `listener.onEliminatorApplied()`
2. `StepRecorder.onEliminatorApplied()` was a no-op
3. There was no constraint propagation loop — the solver jumped straight to backtracking

## Changes
- **Added** `displayName` property to `CandidateEliminator` interface
- **Added** `countTotalCandidates()` to `Board` for before/after detection
- **Restructured** `solveInternal` with a constraint propagation loop before backtracking
- **Implemented** `StepRecorder.onEliminatorApplied()` to create technique steps
- **Added** `TECHNIQUE_APPLIED` step type with `fromTechniqueName()` mapping
- **Added** `techniqueApplied()` factory method to `SolvingStep`
- **Improved** "Only candidate" explanation to "Naked Single at (row,col)"
- **Added** displayName overrides for Simple/Group/Exclusion/HiddenSubset eliminators
- **Preserved** original board for uniqueness fallback

## Testing
- ✅ All 398 tests pass (`./gradlew test`)
- ✅ Frontend lint passes (`npm run lint:ci`)
- ✅ Frontend builds (`npm run build`)
- ✅ Backend builds (`./gradlew :web:installDist`)

## Files Modified
- `kotlin/src/main/java/will/sudoku/solver/Board.kt` — added `countTotalCandidates()`
- `kotlin/src/main/java/will/sudoku/solver/CandidateEliminator.kt` — added `displayName`
- `kotlin/src/main/java/will/sudoku/solver/Solver.kt` — restructured with propagation loop
- `kotlin/src/main/java/will/sudoku/solver/SolvingStep.kt` — added `techniqueApplied()`
- `kotlin/src/main/java/will/sudoku/solver/StepRecorder.kt` — implemented technique recording
- `kotlin/src/main/java/will/sudoku/solver/StepType.kt` — added `TECHNIQUE_APPLIED` + mapping
- 4 eliminator files — added `displayName` overrides