### PR TITLE
fix: add Naked Single detection to HintGenerator

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/HintGenerator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/HintGenerator.kt
@@ -45,6 +45,7 @@ object HintGenerator {
      * Ordered from easiest to hardest.
      */
     enum class Technique(val displayName: String, val description: String) {
+        NAKED_SINGLE("Naked Single", "Only one candidate fits in this cell"),
         HIDDEN_SINGLE("Hidden Single", "This value appears only once in a row, column, or region"),
         POINTING_PAIR("Pointing Pair", "A candidate restricted to one row/col in a box"),
         BOX_LINE_REDUCTION("Box/Line Reduction", "Candidates restricted to one box in a row/col"),
@@ -243,6 +244,7 @@ object HintGenerator {
      */
     private fun detectTechnique(board: Board, technique: Technique): Hint? {
         return when (technique) {
+            Technique.NAKED_SINGLE -> findNakedSingle(board)
             Technique.HIDDEN_SINGLE -> findHiddenSingle(board)
             Technique.POINTING_PAIR -> findPointingPair(board)
             Technique.NAKED_PAIR -> findNakedPair(board)
@@ -316,7 +318,43 @@ object HintGenerator {
     }
 
     /**
-     * Find a hidden single (easiest technique).
+     * Find a naked single (easiest technique).
+     * A cell with only one remaining candidate.
+     */
+    private fun findNakedSingle(board: Board): Hint? {
+        for (coord in Coord.all) {
+            if (board.isConfirmed(coord)) continue
+            val candidates = board.candidateValues(coord)
+            if (candidates.size == 1) {
+                val value = candidates.first()
+                val seen = mutableSetOf<Int>()
+                for (i in 0..8) {
+                    seen.add(board.value(Coord(coord.row, i)))
+                    seen.add(board.value(Coord(i, coord.col)))
+                }
+                val boxRow = coord.row / 3 * 3
+                val boxCol = coord.col / 3 * 3
+                for (r in boxRow until boxRow + 3) {
+                    for (c in boxCol until boxCol + 3) {
+                        seen.add(board.value(Coord(r, c)))
+                    }
+                }
+                seen.remove(0)
+                return Hint(
+                    coord = coord,
+                    value = value,
+                    technique = Technique.NAKED_SINGLE,
+                    explanation = "Cell (${coord.row + 1}, ${coord.col + 1}) can only be $value! " +
+                            "All other numbers ${(1..9).filter { it != value && it !in seen }.joinToString(", ")} " +
+                            "are already present in the row, column, or box."
+                )
+            }
+        }
+        return null
+    }
+
+    /**
+     * Find a hidden single.
      */
     internal fun findHiddenSingle(board: Board): Hint? {
         for (coordGroup in CoordGroup.all) {

--- a/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
@@ -78,6 +78,7 @@ class TeachingHintProvider {
 
     private fun mapTechniqueToHintType(technique: HintGenerator.Technique): HintType {
         return when (technique) {
+            HintGenerator.Technique.NAKED_SINGLE -> HintType.NAKED_SINGLE
             HintGenerator.Technique.HIDDEN_SINGLE -> HintType.HIDDEN_SINGLE
             HintGenerator.Technique.POINTING_PAIR -> HintType.POINTING_PAIR
             HintGenerator.Technique.BOX_LINE_REDUCTION -> HintType.BOX_LINE_REDUCTION
@@ -145,6 +146,11 @@ class TeachingHintProvider {
 
     private fun techniqueTeachingPoints(technique: HintGenerator.Technique): List<String> {
         return when (technique) {
+            HintGenerator.Technique.NAKED_SINGLE -> listOf(
+                "Look at the row, column, and box containing this cell",
+                "Only one number is possible — all others are already used",
+                "This is called a 'Naked Single' because the answer is obvious once you check the peers"
+            )
             HintGenerator.Technique.HIDDEN_SINGLE -> listOf(
                 "Look for a number that appears only once in a row, column, or box",
                 "Check each row, column, and box systematically",


### PR DESCRIPTION
Closes #224

## Problem
Easy/medium puzzles were returning generic `Scanning` hints with `cell: null` because `HintGenerator`'s `Technique` enum had no Naked Single detection. After exhausting hidden singles, no technique could be found and the hint fell through to a generic fallback.

## Root Cause
`HintGenerator.generate()` exhausts all hidden singles before checking techniques. For easy/medium puzzles, after this exhaustion, the only remaining moves are Naked Singles — but there was no detection for them. Hard/expert puzzles are unaffected because they have genuinely advanced techniques.

## Changes
- Added `NAKED_SINGLE` as the first (easiest) technique in `Technique` enum
- Added `findNakedSingle()` method using candidate bitmask detection
- Added `NAKED_SINGLE` mapping in `TeachingHintProvider`
- Added technique-specific teaching points for Naked Single

## Testing
- [x] All 398+ tests pass (`./gradlew test`)
- [x] Frontend lint passes (`npm run lint:ci` — 0 warnings)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)
- [x] No regression for hard/expert puzzles (Naked Singles don't appear after constraint propagation + hidden single exhaustion on hard puzzles)