### PR TITLE
fix: step-by-step solver emits cell-level detail in each step

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/Solver.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/Solver.kt
@@ -128,12 +128,36 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
         while (anyProgress) {
             anyProgress = false
             for (eliminator in config.eliminators) {
-                val candidatesBefore = board.countTotalCandidates()
+                // Snapshot candidate values for all unresolved cells before running eliminator
+                val beforeState: Map<Coord, Set<Int>> = Coord.all
+                    .filter { !board.isConfirmed(it) }
+                    .associateWith { board.candidateValues(it).toSet() }
+
                 val changed = eliminator.eliminate(board)
                 if (changed) {
-                    val eliminated = candidatesBefore - board.countTotalCandidates()
-                    if (eliminated > 0) {
-                        listener.onEliminatorApplied(eliminator.displayName, eliminated)
+                    // Compute per-cell diffs: which cells lost which candidates
+                    val eliminations = mutableListOf<Elimination>()
+                    beforeState.forEach { (coord, beforeValues) ->
+                        if (!board.isConfirmed(coord)) {
+                            val afterValues = board.candidateValues(coord).toSet()
+                            val removed = beforeValues - afterValues
+                            if (removed.isNotEmpty()) {
+                                eliminations.add(Elimination(coord, removed))
+                            }
+                        } else {
+                            // Cell became confirmed — all values except the confirmed one were eliminated
+                            val confirmedValue = board.value(coord)
+                            val removed = beforeValues - setOf(confirmedValue)
+                            if (removed.isNotEmpty()) {
+                                eliminations.add(Elimination(coord, removed))
+                            }
+                        }
+                    }
+
+                    val totalEliminated = eliminations.sumOf { it.eliminatedValues.size }
+                    if (totalEliminated > 0) {
+                        listener.onEliminatorApplied(eliminator.displayName, totalEliminated)
+                        listener.onCandidatesEliminated(eliminator.displayName, eliminations)
                     }
                     anyProgress = true
                 }

--- a/kotlin/src/main/java/will/sudoku/solver/SolvingListener.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/SolvingListener.kt
@@ -4,6 +4,17 @@ import will.sudoku.solver.Board
 import will.sudoku.solver.Coord
 
 /**
+ * Records a candidate elimination at a specific cell.
+ *
+ * @param cell The coordinate where candidates were eliminated
+ * @param eliminatedValues The values that were removed from this cell
+ */
+data class Elimination(
+    val cell: Coord,
+    val eliminatedValues: Set<Int>
+)
+
+/**
  * Listener interface for observing and recording the solving process.
  *
  * Implement this interface to receive callbacks at key points during solving.
@@ -75,6 +86,18 @@ interface SolvingListener {
      * @param eliminations Number of candidates eliminated by this technique
      */
     fun onEliminatorApplied(name: String, eliminations: Int) {}
+
+    /**
+     * Called when candidates are eliminated at specific cells by a technique.
+     *
+     * This provides cell-level detail (which cells, which values) for step-by-step
+     * solving features. Unlike [onEliminatorApplied] which only reports aggregate counts,
+     * this callback includes the full list of per-cell eliminations.
+     *
+     * @param name Name of the elimination technique (e.g., "Naked Pair")
+     * @param eliminations List of per-cell eliminations with affected coordinates and removed values
+     */
+    fun onCandidatesEliminated(name: String, eliminations: List<Elimination>) {}
     
     /**
      * Called when solving is complete.
@@ -131,6 +154,10 @@ class CompositeListener(vararg listeners: SolvingListener) : SolvingListener {
     
     override fun onEliminatorApplied(name: String, eliminations: Int) {
         listeners.forEach { it.onEliminatorApplied(name, eliminations) }
+    }
+
+    override fun onCandidatesEliminated(name: String, eliminations: List<Elimination>) {
+        listeners.forEach { it.onCandidatesEliminated(name, eliminations) }
     }
     
     override fun onSolveComplete(solved: Boolean, timeNanos: Long, backtracks: Int) {

--- a/kotlin/src/main/java/will/sudoku/solver/StepRecorder.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/StepRecorder.kt
@@ -79,13 +79,35 @@ class StepRecorder : SolvingListener {
     }
     
     override fun onEliminatorApplied(name: String, eliminations: Int) {
+        // Per-cell detail is handled by onCandidatesEliminated.
+        // This aggregate callback is kept for backward compatibility with other listeners.
+    }
+
+    override fun onCandidatesEliminated(name: String, eliminations: List<Elimination>) {
+        if (eliminations.isEmpty()) return
+
         stepNumber++
+        val affectedCells = eliminations.map { it.cell }
+        val allValues = eliminations.flatMap { it.eliminatedValues }.toSet()
+        val totalEliminated = eliminations.sumOf { it.eliminatedValues.size }
+
+        // Build human-readable per-cell explanation
+        val cellDescs = eliminations.sortedBy { "${it.cell.row},${it.cell.col}" }
+            .joinToString("; ") { e ->
+                val cellLabel = "(${e.cell.row + 1}, ${e.cell.col + 1})"
+                val vals = e.eliminatedValues.sorted().joinToString(",")
+                "$cellLabel: [$vals]"
+            }
+
         val stepType = StepType.fromTechniqueName(name)
-        _steps.add(SolvingStep.techniqueApplied(
+        val explanation = "$name: $totalEliminated candidate(s) eliminated — $cellDescs"
+
+        _steps.add(SolvingStep(
             stepNumber = stepNumber,
-            techniqueName = name,
-            eliminations = eliminations,
-            explanation = "$name: $eliminations candidate(s) eliminated"
+            stepType = stepType,
+            affectedCells = affectedCells,
+            values = allValues,
+            explanation = explanation
         ))
     }
     


### PR DESCRIPTION
Closes #293

## Problem
The step-by-step solver lumped all eliminations from a technique pass into a single step with empty affectedCells and values arrays.

## Fix
- Added Elimination data class for per-cell tracking
- Added onCandidatesEliminated() callback to SolvingListener
- Solver.solveInternal() snapshots candidates, computes per-cell diffs
- StepRecorder now creates steps with populated affectedCells and values

## Before/After
**Before:** `{"affectedCells": [], "values": [], "explanation": "Simple Elimination: 280 candidate(s) eliminated"}`
**After:** `{"affectedCells": [{"row":0,"col":1},...], "values": [1,2,3,4,5,6,7,8,9], "explanation": "Simple Elimination: 280 candidate(s) eliminated — (1,2): [1,3,4,5,6,7,8,9]; ..."}`

Hard puzzles now show 11 steps with per-technique cell detail (Simple Elimination, Naked Subset, Hidden Single, X-Wing, W-Wing, ForcingChains, ALS-XZ, FrankenFish).

## Testing
- [x] All 398 tests pass
- [x] Frontend lint & build pass
- [x] Smoke tested with easy and hard puzzles
