### PR TITLE
fix: upgrade Kotlin from 2.3.20 to 2.3.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.3.20" apply false
+    kotlin("jvm") version "2.3.21" apply false
     id("org.sonarqube") version "4.4.1.3373"
 }
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -2,8 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     java
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.serialization") version "2.3.20"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.serialization") version "2.3.21"
     id("me.champeau.jmh") version "0.7.3"
     jacoco
 }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.serialization") version "2.3.20"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.serialization") version "2.3.21"
     application
 }
 


### PR DESCRIPTION
Closes #269

## Changes
- Updated Kotlin version from 2.3.20 → 2.3.21 in all 3 build files:
  - `build.gradle.kts`
  - `kotlin/build.gradle.kts`
  - `web/build.gradle.kts`

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend lint passes (`npm run lint:ci`)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)