### PR TITLE
docs: update tester and planner to create GitHub issues

### DIFF
--- a/docs/agents/skills/sudoku-planner.md
+++ b/docs/agents/skills/sudoku-planner.md
@@ -12,7 +12,8 @@ Strategic planning agent. Understands the codebase and production state without 
 - Read and analyze code structure
 - Read server logs for errors, performance issues, anomalies
 - Spawn small worker tasks to probe the live server
-- Create detailed implementation plans for the coder agent
+- Create detailed implementation plans as GitHub issues with the `plan` label
+- Reference related bug issues in plans
 - Maintain the project roadmap
 
 ## What This Agent Does NOT Do
@@ -101,31 +102,41 @@ using the test puzzle. Report average response time and any errors."
 
 ## Creating Implementation Plans
 
-Plans should be written to `memory/sudoku-solver-roadmap.md` in the "Current Sprint" section or as a separate plan file. Format:
+Plans are created as **GitHub issues** with the `plan` label so they are visible to all contributors. Reference related bug issues in the plan body.
 
-```markdown
-## Plan: [Feature Name]
-**Date:** YYYY-MM-DD
-**Priority:** High/Medium/Low
-**Scope:** Backend / Frontend / Both
+```bash
+# Create a plan issue
+github issue create --repo sudoku-solver-bot/sudoku-solver \
+  --title "plan: [Feature Name]" \
+  --label "plan,priority:medium" \
+  --body "Addresses #<BUG_NUMBER>
 
-### Objective
+## Objective
 [What this achieves in 1-2 sentences]
 
-### Files to Change
-- `path/to/file.ext` — [what to change]
+## Current → Target
+- Component: old → new
 
-### Implementation Steps
+## Scope
+- [ ] Backend
+- [ ] Frontend
+
+## Files to Change
+- \`path/to/file.ext\` — [what to change]
+
+## Implementation Steps
 1. [Step 1]
 2. [Step 2]
 ...
 
-### Testing
+## Testing
 - [How to verify]
 
-### Estimated Effort
-[X] hours
+## Estimated Effort
+[X] hours"
 ```
+
+Plans may also be maintained in the roadmap file at `memory/sudoku-solver-roadmap.md` for long-term tracking.
 
 ## GitHub Status Review
 

--- a/docs/agents/skills/sudoku-tester.md
+++ b/docs/agents/skills/sudoku-tester.md
@@ -15,11 +15,12 @@ Active QA agent that exercises the live sudoku-solver server and finds bugs.
 - Tests edge cases (invalid input, empty puzzles, malformed data)
 - Compares local vs remote server responses
 - Reports all findings as structured bug reports for the planner
+- Creates GitHub issues for every bug found (🔴🟠🟡 severity)
+- Summarizes test results with issue links
 
 ## What This Agent Does NOT Do
 
 - Never modifies code, config, or files
-- Never creates issues or PRs
 - Never restarts services
 
 ## Server Endpoints
@@ -217,12 +218,55 @@ REMOTE=$(curl -sf -X POST https://sudoku-solver-r5y8.onrender.com/api/v1/solve \
 # Compare solutions
 ```
 
+## Creating GitHub Issues
+
+For every bug found (🔴🟠🟡 severity), create a GitHub issue with the `bug:` prefix:
+
+```bash
+# Create a bug issue
+gh issue create --repo sudoku-solver-bot/sudoku-solver \
+  --title "bug: [Severity] Brief Description" \
+  --label "bug,priority:high" \
+  --body "## Bug Report
+
+**Endpoint:** \`POST /api/v1/hint\`
+**Input:** \`{\"puzzle\":\"007239061...\"}\`
+**Expected:** Technique \"Hidden Single\" with specific cell
+**Actual:** Generic \"Scanning\" hint with no cell
+
+**Steps to Reproduce:**
+1. Generate a medium puzzle
+2. Request hint
+3. Observe generic response
+
+**Impact:** Users don't get useful hints for medium+ puzzles
+"
+```
+
+Priority labels:
+- 🔴 Critical → `priority:high`
+- 🟠 Major → `priority:high`
+- 🟡 Minor → `priority:medium`
+- 🔵 Cosmetic → `priority:low`
+
+After creating all bug issues, post a summary comment on the primary issue or roadmap:
+
+```bash
+# Summarize with links
+gh issue comment <NUMBER> --repo sudoku-solver-bot/sudoku-solver \
+  --body "Test run complete:
+- 🟠 #xxx: Hint returns generic 'Scanning'
+- 🟡 #yyy: Tutorial naked-pair step 3 has empty text
+- 🔵 #zzz: Typo in swordfish description
+"
+```
+
 ## Bug Report Format
 
-When you find an issue, report it in this format:
+When you find an issue, report it in this GitHub-friendly format:
 
 ```markdown
-### 🐛 [Severity] Brief Description
+### bug: 🐛 [Severity] Brief Description
 
 **Endpoint:** `POST /api/v1/hint`
 **Input:** `{"puzzle":"007239061..."}`
@@ -245,10 +289,12 @@ Severity levels:
 
 ## Rules
 
-1. **Read-only** — only probe, never modify
+1. **Read-only** — only probe, never modify code
 2. Test ALL 20 tutorials every run
 3. Test ALL difficulty levels for generate
 4. Always validate solve results (correct sudoku solution)
 5. Report concrete reproducible bugs, not vague concerns
 6. Compare local vs remote at least once per run
-7. Report findings to the planner by updating the roadmap or creating a findings file
+7. **Create GitHub issues for every bug** — use `bug:` prefix and appropriate priority label
+8. **Always check for duplicate issues before creating** — search existing issues to avoid duplicates
+9. **Summarize findings** — post a summary comment with links to all created issues


### PR DESCRIPTION
Closes #219

## Changes

### Tester (`docs/agents/skills/sudoku-tester.md`)
- **What This Agent Does**: added creation of GitHub issues for bugs and summary with issue links
- **What This Agent Does NOT Do**: removed "Never creates issues or PRs" — tester now creates bug issues
- **New: Creating GitHub Issues** section with `bug:` prefix format, priority label mapping, and summary comment template
- **Bug Report Format**: updated to use `bug:` prefix in issue titles
- **Rules**: replaced roadmap-only reporting with GitHub issue creation + duplicate check + summary

### Planner (`docs/agents/skills/sudoku-planner.md`)
- **What This Agent Does**: plans are now GitHub issues with `plan` label; references related bug issues
- **Creating Implementation Plans**: replaced roadmap-file format with `gh issue create` command using `plan` label and `plan:` prefix

## Testing
- Docs-only change, no code changes