### PR TITLE
fix: return hidden single hint when board solved by hidden singles

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/HintGenerator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/HintGenerator.kt
@@ -93,8 +93,16 @@ object HintGenerator {
 
         // Step 2 (optional): Apply hidden singles to advance the board before checking techniques.
         // This is useful for tutorials where we want to demonstrate a specific advanced technique.
+        var lastHiddenSingle: Hint? = null
         if (exhaustHiddenSingles) {
-            applyHiddenSinglesUntilStable(workingBoard)
+            lastHiddenSingle = applyHiddenSinglesUntilStable(workingBoard)
+        }
+
+        // Step 2.5: If the board is now solved, return the last hidden single found.
+        // Without this, puzzles solvable entirely by hidden singles would fall through
+        // to the generic "Scanning" fallback (bug #224).
+        if (workingBoard.isSolved() && lastHiddenSingle != null) {
+            return lastHiddenSingle
         }
 
         // Step 3: If a target technique is specified, check it first.
@@ -136,7 +144,8 @@ object HintGenerator {
      * after all hidden singles have been exhausted — i.e., the hint returns the "next
      * technique actually needed" rather than the "easiest technique present."
      */
-    internal fun applyHiddenSinglesUntilStable(board: Board) {
+    internal fun applyHiddenSinglesUntilStable(board: Board): Hint? {
+        var lastHint: Hint? = null
         var foundAny = true
         while (foundAny) {
             foundAny = false
@@ -147,6 +156,7 @@ object HintGenerator {
                 val hint = findHiddenSingle(board)
                 if (hint != null) {
                     board.markValue(hint.coord, hint.value)
+                    lastHint = hint
                     foundAny = true
                     foundOne = true
                     // Re-run constraint propagation after each hidden single
@@ -156,6 +166,7 @@ object HintGenerator {
                 }
             } while (foundOne)
         }
+        return lastHint
     }
 
     /**


### PR DESCRIPTION
Closes #224

## Problem
`POST /api/v1/hint` always returned generic "Scanning" technique with `cell: null` for puzzles solvable entirely by hidden singles. The `HintGenerator.generate()` function exhausted hidden singles, solved the board, then returned null because no technique was detected on the already-solved board. The `TeachingHintProvider` then fell back to the generic "Scanning" fallback.

## Fix
- Changed `applyHiddenSinglesUntilStable()` to return the last hidden single found
- In `generate()`, after exhausting hidden singles, check if the board is solved and return the last hidden single as a proper hint with cell, value, and technique

## Changes
- `kotlin/src/main/java/will/sudoku/solver/HintGenerator.kt`: 
  - `applyHiddenSinglesUntilStable()` now returns `Hint?` instead of `Unit`
  - `generate()` captures the return value and uses it when the board is solved

## Testing
- [x] Compilation passes
- [x] Frontend lint passes
- CI will run full backend tests