### PR TITLE
fix: pass tutorial technique to hint system for correct technique targeting

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
@@ -44,14 +44,14 @@ enum class HintType {
  */
 class TeachingHintProvider {
 
-    fun getHint(board: Board): TeachingHint {
+    fun getHint(board: Board, targetTechnique: HintGenerator.Technique? = null): TeachingHint {
         // Try Naked Single (easiest) — local check for richer teaching points
         findNakedSingle(board)?.let { return it }
 
         // Delegate to HintGenerator for all other techniques.
-        // For tutorials that need a specific advanced technique, the caller should
-        // exhaust hidden singles on the board first via HintGenerator.applyHiddenSinglesUntilStable().
-        val hintGenHint = HintGenerator.generate(board)
+        // For tutorials that need a specific advanced technique, pass targetTechnique
+        // so the hint system prioritizes the technique being taught.
+        val hintGenHint = HintGenerator.generate(board, targetTechnique = targetTechnique)
         if (hintGenHint != null) {
             return TeachingHint(
                 type = mapTechniqueToHintType(hintGenHint.technique),

--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -1134,7 +1134,9 @@ const getHint = async () => {
   loading.value = true
   loadingMessage.value = 'Finding hint...'
   try {
-    const data = await getHintForPuzzle(puzzle.value)
+    // Pass target technique in tutorial mode so hint system prioritizes the taught technique
+    const targetTechnique = tutorialMode.value ? currentTutorialLesson.value?.technique : undefined
+    const data = await getHintForPuzzle(puzzle.value, targetTechnique)
     if (data.hasHint) {
       currentHint.value = data.hint
       hintsUsed.value++

--- a/web-ui/src/api.ts
+++ b/web-ui/src/api.ts
@@ -25,9 +25,11 @@ export async function generatePuzzle(difficulty = 'MEDIUM'): Promise<unknown> {
 }
 
 // Hint
-export async function getHintForPuzzle(puzzle: string): Promise<unknown> {
+export async function getHintForPuzzle(puzzle: string, technique?: string): Promise<unknown> {
   const normalized = puzzle.replace(/\./g, '0')
-  return apiPost(`${API_BASE}/hint`, { puzzle: normalized })
+  const body: Record<string, string> = { puzzle: normalized }
+  if (technique) body.technique = technique
+  return apiPost(`${API_BASE}/hint`, body)
 }
 
 // Validate

--- a/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import will.sudoku.solver.Board
 import will.sudoku.solver.BoardReader
+import will.sudoku.solver.HintGenerator
 import will.sudoku.solver.HintType
 import will.sudoku.solver.SimpleCandidateEliminator
 import will.sudoku.solver.TeachingHintProvider
@@ -20,7 +21,8 @@ fun Board.withConstraintPropagation(): Board {
 
 @Serializable
 data class HintRequest(
-    val puzzle: String
+    val puzzle: String,
+    val technique: String? = null  // Optional: target technique for tutorial mode
 )
 
 @Serializable
@@ -73,7 +75,16 @@ fun Route.hintRoutes() {
         }
 
         val board = rawBoard.withConstraintPropagation()
-        val hint = hintProvider.getHint(board)
+        
+        // Map requested technique string to HintGenerator.Technique enum
+        val targetTechnique = request.technique?.let { techName ->
+            HintGenerator.Technique.entries.find {
+                it.displayName.equals(techName, ignoreCase = true) ||
+                it.name.equals(techName, ignoreCase = true)
+            }
+        }
+        
+        val hint = hintProvider.getHint(board, targetTechnique)
 
         call.respond(
             HintResponse(


### PR DESCRIPTION
Closes #308

## Problem
14/20 tutorials returned wrong hint technique (mostly Pointing Pair instead of the taught technique). Tutorial examplePuzzles didn't require the taught technique — the hint system always returned the easiest applicable technique, which was rarely the one being taught.

## Root Cause
`HintGenerator.generate()` already supports a `targetTechnique` parameter that checks the target technique BEFORE iterating from easiest to hardest. But the hint API and teaching hint provider never used it.

## Changes

### Backend
- **`HintRequest`**: added optional `technique` field
- **`HintRoutes`**: maps technique string to `HintGenerator.Technique` enum and passes it to provider
- **`TeachingHintProvider.getHint()`**: accepts optional `targetTechnique` and passes to `HintGenerator.generate()`

### Frontend  
- **`api.ts`**: `getHintForPuzzle()` accepts optional technique string
- **`App.vue`**: passes `currentTutorialLesson.technique` when in tutorial mode

## Note
This fixes the hint system to correctly target the taught technique. However, some tutorial puzzles may still not exercise the taught technique at all (puzzle quality issue). Fixing individual tutorial puzzles is tracked separately.

## Testing
- [x] Backend compilation passes
- [x] Frontend lint passes
- CI will run full test suite