### PR TITLE
feat: port solver data model to TypeScript (Coord, CoordGroup, Board)

### DIFF
--- a/web-ui/src/solver/Board.ts
+++ b/web-ui/src/solver/Board.ts
@@ -1,0 +1,242 @@
+import { Coord } from './Coord'
+import { CoordGroup } from './CoordGroup'
+import { SIZE, SYMBOLS, WILDCARD_PATTERN } from './BoardSettings'
+
+/**
+ * Bit masks for individual values 1-9.
+ *
+ * masks[0] = 0b000000001 (value 1)
+ * masks[1] = 0b000000010 (value 2)
+ * ...
+ * masks[8] = 0b100000000 (value 9)
+ */
+const MASKS: readonly number[] = Object.freeze(Array.from({ length: SIZE }, (_, i) => 1 << i))
+
+/**
+ * Represents a Sudoku puzzle board with 81 cells arranged in a 9×9 grid.
+ *
+ * Uses a bitmask-based candidate representation:
+ * - Each cell's candidate pattern is a 9-bit integer.
+ * - Bit i (0-indexed) corresponds to value i+1.
+ * - A confirmed cell has exactly one bit set.
+ * - An empty/unknown cell has all 9 bits set (WILDCARD_PATTERN = 511).
+ *
+ * Equivalent to the Kotlin `Board` class.
+ */
+export class Board {
+    /** 81 candidate patterns, one per cell. */
+    readonly candidatePatterns: Int32Array
+
+    /**
+     * @param candidatePatterns 81-element array of bitmask patterns.
+     * @throws If array length is not 81.
+     */
+    constructor(candidatePatterns: Int32Array | number[] | Uint16Array) {
+        if (candidatePatterns.length !== 81) {
+            throw new Error(`Expected 81 cells, got ${candidatePatterns.length}`)
+        }
+        this.candidatePatterns =
+            candidatePatterns instanceof Int32Array
+                ? candidatePatterns
+                : new Int32Array(candidatePatterns)
+    }
+
+    // ---------------------------------------------------------------------------
+    // Construction helpers
+    // ---------------------------------------------------------------------------
+
+    /** Create a board from an 81-element array of placed values (0 = empty). */
+    static fromValues(values: readonly number[]): Board {
+        const patterns = new Int32Array(81)
+        for (let i = 0; i < 81; i++) {
+            const v = values[i]
+            patterns[i] = v === 0 ? WILDCARD_PATTERN : MASKS[v - 1]
+        }
+        return new Board(patterns)
+    }
+
+    /** Create an empty board (all cells are wildcards). */
+    static empty(): Board {
+        return new Board(new Int32Array(81).fill(WILDCARD_PATTERN))
+    }
+
+    // ---------------------------------------------------------------------------
+    // Equality & copy
+    // ---------------------------------------------------------------------------
+
+    equals(other: Board): boolean {
+        for (let i = 0; i < 81; i++) {
+            if (this.candidatePatterns[i] !== other.candidatePatterns[i]) return false
+        }
+        return true
+    }
+
+    copy(): Board {
+        return new Board(new Int32Array(this.candidatePatterns))
+    }
+
+    // ---------------------------------------------------------------------------
+    // Status checking
+    // ---------------------------------------------------------------------------
+
+    /** Display symbol for a cell ('.' for empty, '1'-'9' for confirmed). */
+    symbolAt(coord: Coord): string {
+        return SYMBOLS[this.value(coord)]
+    }
+
+    /** True if exactly one candidate value remains. */
+    isConfirmed(coord: Coord): boolean {
+        return bitCount(this.candidatePatterns[coord.index]) === 1
+    }
+
+    /** True if the board is valid (no contradictions). */
+    isValid(): boolean {
+        // No cell should have zero candidates.
+        for (let i = 0; i < 81; i++) {
+            if (this.candidatePatterns[i] === 0) return false
+        }
+        // No group should contain duplicate confirmed values.
+        for (const group of CoordGroup.all) {
+            const seen = new Set<number>()
+            for (const c of group.coords) {
+                if (this.isConfirmed(c)) {
+                    const pat = this.candidatePatterns[c.index]
+                    if (seen.has(pat)) return false
+                    seen.add(pat)
+                }
+            }
+        }
+        return true
+    }
+
+    /** True if all 81 cells are confirmed. */
+    isSolved(): boolean {
+        for (let i = 0; i < 81; i++) {
+            if (bitCount(this.candidatePatterns[i]) !== 1) return false
+        }
+        return true
+    }
+
+    // ---------------------------------------------------------------------------
+    // Candidate pattern access
+    // ---------------------------------------------------------------------------
+
+    /** Raw bitmask pattern for a cell. */
+    candidatePattern(coord: Coord): number {
+        return this.candidatePatterns[coord.index]
+    }
+
+    /** Array of possible values (1-9) for a cell. */
+    candidateValues(coord: Coord): number[] {
+        const pat = this.candidatePatterns[coord.index]
+        const result: number[] = []
+        for (let i = 0; i < SIZE; i++) {
+            if (pat & MASKS[i]) result.push(i + 1)
+        }
+        return result
+    }
+
+    // ---------------------------------------------------------------------------
+    // Candidate manipulation
+    // ---------------------------------------------------------------------------
+
+    /** Erase a candidate pattern from a cell. Returns true if changed. */
+    eraseCandidatePattern(coord: Coord, pattern: number): boolean {
+        const idx = coord.index
+        const old = this.candidatePatterns[idx]
+        this.candidatePatterns[idx] = old & ~pattern
+        return old !== this.candidatePatterns[idx]
+    }
+
+    /** Erase candidate value (1-9) from a cell. Returns true if changed. */
+    eraseCandidateValue(coord: Coord, value: number): boolean {
+        return this.eraseCandidatePattern(coord, MASKS[value - 1])
+    }
+
+    // ---------------------------------------------------------------------------
+    // Confirmed value manipulation
+    // ---------------------------------------------------------------------------
+
+    /** Get the confirmed value (1-9), or 0 if not confirmed. */
+    value(coord: Coord): number {
+        const pat = this.candidatePatterns[coord.index]
+        for (let i = 0; i < SIZE; i++) {
+            if (pat === MASKS[i]) return i + 1
+        }
+        return 0
+    }
+
+    /** Set a confirmed value (1-9) for a cell. */
+    markValue(coord: Coord, value: number): void {
+        this.candidatePatterns[coord.index] = MASKS[value - 1]
+    }
+
+    // ---------------------------------------------------------------------------
+    // Solver helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Find the unresolved cell with the fewest candidates (MRV heuristic).
+     * Returns undefined if solved.
+     */
+    unresolvedCoord(): Coord | undefined {
+        let best: Coord | undefined
+        let bestCount = SIZE + 1
+        for (const c of Coord.all) {
+            if (this.isConfirmed(c)) continue
+            const count = bitCount(this.candidatePatterns[c.index])
+            if (count < bestCount) {
+                bestCount = count
+                best = c
+                if (count === 2) break // cannot get better than 2 candidates
+            }
+        }
+        return best
+    }
+
+    /** Total number of candidates across all cells. */
+    countTotalCandidates(): number {
+        let total = 0
+        for (let i = 0; i < 81; i++) {
+            total += bitCount(this.candidatePatterns[i])
+        }
+        return total
+    }
+
+    // ---------------------------------------------------------------------------
+    // Display
+    // ---------------------------------------------------------------------------
+
+    toString(): string {
+        const lines: string[] = []
+        for (let regionRow = 0; regionRow < 3; regionRow++) {
+            for (let rowInRegion = 0; rowInRegion < 3; rowInRegion++) {
+                const row = regionRow * 3 + rowInRegion
+                const parts: string[] = []
+                for (let regionCol = 0; regionCol < 3; regionCol++) {
+                    const cells: string[] = []
+                    for (let colInRegion = 0; colInRegion < 3; colInRegion++) {
+                        const col = regionCol * 3 + colInRegion
+                        cells.push(this.symbolAt(Coord.all[row * 9 + col]))
+                    }
+                    parts.push(cells.join(''))
+                }
+                lines.push(parts.join('|'))
+            }
+            if (regionRow < 2) lines.push('---+---+---')
+        }
+        return lines.join('\n')
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Count set bits (popcount) in a 32-bit integer. */
+function bitCount(n: number): number {
+    n = n - ((n >>> 1) & 0x55555555)
+    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333)
+    n = (n + (n >>> 4)) & 0x0f0f0f0f
+    return (n * 0x01010101) >>> 24
+}

--- a/web-ui/src/solver/BoardSettings.ts
+++ b/web-ui/src/solver/BoardSettings.ts
@@ -1,0 +1,13 @@
+/**
+ * Board-level constants shared across the solver.
+ * Mirrors the Kotlin `BoardSettings` object.
+ */
+export const SIZE = 9
+export const REGION_SIZE = 3
+export const CELL_COUNT = SIZE * SIZE // 81
+
+/** Symbol for display: index = value (0 = empty → '.', 1-9 = '1'-'9'). */
+export const SYMBOLS: readonly string[] = ['.', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+/** Bitmask for the wildcard (all candidates possible). */
+export const WILDCARD_PATTERN = (1 << SIZE) - 1 // 0b111111111 = 511

--- a/web-ui/src/solver/Coord.ts
+++ b/web-ui/src/solver/Coord.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure data model for a Sudoku coordinate (row, col) with pre-computed
+ * linear index and region.
+ *
+ * Equivalent to the Kotlin `Coord` class.
+ */
+export class Coord {
+    /** 0-based row index (0-8). */
+    readonly row: number
+    /** 0-based column index (0-8). */
+    readonly col: number
+    /** Linear index: row * 9 + col (0-80). */
+    readonly index: number
+    /** Region index 0-8 (left-to-right, top-to-bottom). */
+    readonly region: number
+
+    private constructor(row: number, col: number) {
+        this.row = row
+        this.col = col
+        this.index = row * 9 + col
+        const regionRow = Math.floor(row / 3)
+        const regionCol = Math.floor(col / 3)
+        this.region = regionRow * 3 + regionCol
+    }
+
+    // ---------------------------------------------------------------------------
+    // Pre-computed instances
+    // ---------------------------------------------------------------------------
+    private static _all?: readonly Coord[]
+
+    /** All 81 coordinates, pre-computed and accessed by index (0-80). */
+    static get all(): readonly Coord[] {
+        if (!Coord._all) {
+            const result: Coord[] = []
+            for (let row = 0; row < 9; row++) {
+                for (let col = 0; col < 9; col++) {
+                    result[row * 9 + col] = new Coord(row, col)
+                }
+            }
+            Coord._all = Object.freeze(result)
+        }
+        return Coord._all
+    }
+}

--- a/web-ui/src/solver/CoordGroup.ts
+++ b/web-ui/src/solver/CoordGroup.ts
@@ -1,0 +1,126 @@
+import { Coord } from './Coord'
+import { SIZE, REGION_SIZE } from './BoardSettings'
+
+/**
+ * Represents a group of coordinates (row, column, or 3×3 region).
+ *
+ * CoordGroups are used by the solver's constraint propagation to validate
+ * that no group contains duplicate values or invalid cell arrangements.
+ *
+ * Equivalent to the Kotlin `CoordGroup` class.
+ */
+export class CoordGroup {
+    /** The list of coordinates in this group. */
+    readonly coords: readonly Coord[]
+
+    constructor(coords: readonly Coord[]) {
+        this.coords = coords
+    }
+
+    // ---------------------------------------------------------------------------
+    // Pre-computed groups
+    // ---------------------------------------------------------------------------
+
+    private static _vertical?: readonly CoordGroup[]
+    private static _horizontal?: readonly CoordGroup[]
+    private static _region?: readonly CoordGroup[]
+    private static _all?: readonly CoordGroup[]
+
+    /** Column groups (9 groups, one per column). */
+    static get vertical(): readonly CoordGroup[] {
+        if (!CoordGroup._vertical) {
+            CoordGroup._vertical = Object.freeze(
+                Array.from({ length: SIZE }, (_, col) =>
+                    new CoordGroup(Array.from({ length: SIZE }, (_, row) => Coord.all[row * SIZE + col]))
+                )
+            )
+        }
+        return CoordGroup._vertical
+    }
+
+    /** Row groups (9 groups, one per row). */
+    static get horizontal(): readonly CoordGroup[] {
+        if (!CoordGroup._horizontal) {
+            CoordGroup._horizontal = Object.freeze(
+                Array.from({ length: SIZE }, (_, row) =>
+                    new CoordGroup(Array.from({ length: SIZE }, (_, col) => Coord.all[row * SIZE + col]))
+                )
+            )
+        }
+        return CoordGroup._horizontal
+    }
+
+    /** 3×3 region groups (9 groups). */
+    static get region(): readonly CoordGroup[] {
+        if (!CoordGroup._region) {
+            CoordGroup._region = Object.freeze(
+                Array.from({ length: SIZE }, (_, ri) => {
+                    const regionRow = Math.floor(ri / REGION_SIZE)
+                    const regionCol = ri % REGION_SIZE
+                    const rowStart = regionRow * REGION_SIZE
+                    const colStart = regionCol * REGION_SIZE
+                    const coords: Coord[] = []
+                    for (let r = rowStart; r < rowStart + REGION_SIZE; r++) {
+                        for (let c = colStart; c < colStart + REGION_SIZE; c++) {
+                            coords.push(Coord.all[r * SIZE + c])
+                        }
+                    }
+                    return new CoordGroup(coords)
+                })
+            )
+        }
+        return CoordGroup._region
+    }
+
+    /** All 27 groups: vertical + horizontal + region. */
+    static get all(): readonly CoordGroup[] {
+        if (!CoordGroup._all) {
+            CoordGroup._all = Object.freeze([
+                ...CoordGroup.vertical,
+                ...CoordGroup.horizontal,
+                ...CoordGroup.region,
+            ])
+        }
+        return CoordGroup._all
+    }
+
+    // ---------------------------------------------------------------------------
+    // Factory methods
+    // ---------------------------------------------------------------------------
+
+    /** The column group containing `coord`. */
+    static verticalOf(coord: Coord): CoordGroup {
+        return CoordGroup.vertical[coord.col]
+    }
+
+    /** The row group containing `coord`. */
+    static horizontalOf(coord: Coord): CoordGroup {
+        return CoordGroup.horizontal[coord.row]
+    }
+
+    /** The 3×3 region group containing `coord`. */
+    static regionOf(coord: Coord): CoordGroup {
+        return CoordGroup.region[coord.region]
+    }
+
+    /** All three groups (vertical, horizontal, region) that contain `coord`. */
+    static of(coord: Coord): readonly CoordGroup[] {
+        return [CoordGroup.verticalOf(coord), CoordGroup.horizontalOf(coord), CoordGroup.regionOf(coord)]
+    }
+
+    /**
+     * Creates a CoordGroup for a rectangular range of cells.
+     *
+     * @param rows Array of row indices (inclusive).
+     * @param cols Array of column indices (inclusive).
+     */
+    static fromRanges(rows: readonly number[], cols: readonly number[]): CoordGroup {
+        const coords: Coord[] = []
+        for (const row of rows) {
+            for (const col of cols) {
+                coords.push(Coord.all[row * SIZE + col])
+            }
+        }
+        return new CoordGroup(coords)
+    }
+}


### PR DESCRIPTION
Closes #310

## Part 1 of #272 — Client-side TypeScript Solver

### Changes
- **`web-ui/src/solver/Coord.ts`** — Row/col/index/region coordinate system with pre-computed `Coord.all` instances
- **`web-ui/src/solver/CoordGroup.ts`** — Pre-computed 27 groups (9 rows + 9 cols + 9 regions) with factory methods: `verticalOf`, `horizontalOf`, `regionOf`, `of`, `fromRanges`
- **`web-ui/src/solver/Board.ts`** — Bitmask-based candidate representation with:
  - `fromValues()` / `empty()` constructors
  - `isConfirmed()`, `isSolved()`, `isValid()` status checks
  - `markValue()`, `eraseCandidateValue()`, `eraseCandidatePattern()` manipulation
  - `unresolvedCoord()` — MRV heuristic for backtracking
  - `copy()` — efficient cloning for backtracking
  - `toString()` — human-readable board output
- **`web-ui/src/solver/BoardSettings.ts`** — Board constants (SIZE=9, REGION_SIZE=3, SYMBOLS, WILDCARD_PATTERN)

### Design
- Pure data model — no eliminator or solver logic (follows issue #310 scope)
- Lazy-initialised pre-computed groups (like Kotlin version)
- `Int32Array` for candidate patterns (performance-optimised)
- Efficient popcount via SWAR bit-hack

### Verification
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] ESLint passes (`--max-warnings 0`)
- [x] Frontend builds (`npm run build`)

### Self-Review
- [x] No unrelated/lint-only/stray changes
- [x] Static build artifacts reverted
- [x] Matches Kotlin patterns