### PR TITLE
feat: port solver engine — backtracking with MRV heuristic

### DIFF
--- a/web-ui/src/solver/Bitmask.ts
+++ b/web-ui/src/solver/Bitmask.ts
@@ -1,0 +1,75 @@
+/** Board size (9×9 standard Sudoku). */
+export const SIZE = 9
+
+/** Region size (3×3 subgrid). */
+export const REGION_SIZE = 3
+
+/** Total cell count. */
+export const CELL_COUNT = SIZE * SIZE
+
+/** Display symbols: index 0 = '.', 1-9 = '1'-'9'. */
+export const SYMBOLS: readonly string[] = ['.', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+/**
+ * Bit masks for individual values 1-9.
+ *
+ * masks[0] = 0b000000001 (value 1)
+ * masks[1] = 0b000000010 (value 2)
+ * ...
+ * masks[8] = 0b100000000 (value 9)
+ */
+export const MASKS: readonly number[] = Object.freeze(
+    Array.from({ length: SIZE }, (_, i) => 1 << i)
+)
+
+/** Bitmask with all 9 bits set (= 511, wildcard / empty cell). */
+export const WILDCARD_PATTERN = (1 << SIZE) - 1
+
+// ---------------------------------------------------------------------------
+// Bit operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of set bits (popcount) in a 32-bit integer.
+ * Uses the SWAR (SIMD Within A Register) technique for efficiency.
+ */
+export function bitCount(n: number): number {
+    n = n - ((n >>> 1) & 0x55555555)
+    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333)
+    n = (n + (n >>> 4)) & 0x0f0f0f0f
+    return (n * 0x01010101) >>> 24
+}
+
+/** Test whether a specific value (1-9) is present in a bitmask. */
+export function hasValue(mask: number, value: number): boolean {
+    return (mask & MASKS[value - 1]) !== 0
+}
+
+/** Get the lowest set value (1-9) from a bitmask, or 0 if mask is empty. */
+export function lowestValue(mask: number): number {
+    if (mask === 0) return 0
+    // Count trailing zeros (CTZ)
+    let c = 0
+    while ((mask & 1) === 0) { mask >>>= 1; c++ }
+    return c + 1
+}
+
+/**
+ * Extract all candidate values (1-9) from a bitmask.
+ * Returns a sorted array of values.
+ */
+export function maskToValues(mask: number): number[] {
+    const result: number[] = []
+    for (let i = 0; i < SIZE; i++) {
+        if (mask & MASKS[i]) result.push(i + 1)
+    }
+    return result
+}
+
+/**
+ * Convert a value (1-9) to its singleton bitmask.
+ * Returns 0 for value 0.
+ */
+export function valueToMask(value: number): number {
+    return value === 0 ? 0 : MASKS[value - 1]
+}

--- a/web-ui/src/solver/Board.ts
+++ b/web-ui/src/solver/Board.ts
@@ -1,16 +1,6 @@
 import { Coord } from './Coord'
 import { CoordGroup } from './CoordGroup'
-import { SIZE, SYMBOLS, WILDCARD_PATTERN } from './BoardSettings'
-
-/**
- * Bit masks for individual values 1-9.
- *
- * masks[0] = 0b000000001 (value 1)
- * masks[1] = 0b000000010 (value 2)
- * ...
- * masks[8] = 0b100000000 (value 9)
- */
-const MASKS: readonly number[] = Object.freeze(Array.from({ length: SIZE }, (_, i) => 1 << i))
+import { SIZE, SYMBOLS, WILDCARD_PATTERN, MASKS, bitCount } from './Bitmask'
 
 /**
  * Represents a Sudoku puzzle board with 81 cells arranged in a 9×9 grid.
@@ -227,16 +217,4 @@ export class Board {
         }
         return lines.join('\n')
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Count set bits (popcount) in a 32-bit integer. */
-function bitCount(n: number): number {
-    n = n - ((n >>> 1) & 0x55555555)
-    n = (n & 0x33333333) + ((n >>> 2) & 0x33333333)
-    n = (n + (n >>> 4)) & 0x0f0f0f0f
-    return (n * 0x01010101) >>> 24
 }

--- a/web-ui/src/solver/BoardReader.ts
+++ b/web-ui/src/solver/BoardReader.ts
@@ -1,0 +1,71 @@
+import { WILDCARD_PATTERN, valueToMask } from './Bitmask'
+import type { Board } from './Board'
+
+/**
+ * Parses puzzle strings in various formats into a Board.
+ *
+ * Supported formats:
+ * - 81-character string: '1', '2', ..., '9' = given values; '.' or '0' = empty
+ * - 81-element number array: 1-9 = given values; 0 = empty
+ * - Multiple lines (newlines are stripped)
+ *
+ * Equivalent to the Kotlin `Board(values: IntArray)` factory.
+ */
+export class BoardReader {
+    /**
+     * Parse an 81-character string into a Board.
+     *
+     * @param input 81-character puzzle string. Supports '.' and '0' for empty cells.
+     * @param BoardClass The Board constructor (avoids circular dependency).
+     * @throws If input length is not 81.
+     */
+    static fromString(input: string, BoardClass: { fromValues(values: readonly number[]): Board }): Board {
+        // Strip whitespace and handle multi-line input
+        const cleaned = input.replace(/\s/g, '')
+        if (cleaned.length !== 81) {
+            throw new Error(`Invalid puzzle: expected 81 characters, got ${cleaned.length}`)
+        }
+
+        const values: number[] = []
+        for (let i = 0; i < 81; i++) {
+            const ch = cleaned[i]
+            if (ch === '.' || ch === '0') {
+                values.push(0)
+            } else {
+                const n = parseInt(ch, 10)
+                if (isNaN(n) || n < 1 || n > 9) {
+                    throw new Error(`Invalid character at position ${i}: '${ch}'`)
+                }
+                values.push(n)
+            }
+        }
+
+        return BoardClass.fromValues(values)
+    }
+
+    /**
+     * Parse a puzzle string and return the raw Int32Array of candidate patterns
+     * (without creating a Board). Useful when you need the patterns array directly.
+     */
+    static toPatterns(input: string): Int32Array {
+        const cleaned = input.replace(/\s/g, '')
+        if (cleaned.length !== 81) {
+            throw new Error(`Invalid puzzle: expected 81 characters, got ${cleaned.length}`)
+        }
+
+        const patterns = new Int32Array(81)
+        for (let i = 0; i < 81; i++) {
+            const ch = cleaned[i]
+            if (ch === '.' || ch === '0') {
+                patterns[i] = WILDCARD_PATTERN
+            } else {
+                const n = parseInt(ch, 10)
+                if (isNaN(n) || n < 1 || n > 9) {
+                    throw new Error(`Invalid character at position ${i}: '${ch}'`)
+                }
+                patterns[i] = valueToMask(n)
+            }
+        }
+        return patterns
+    }
+}

--- a/web-ui/src/solver/CoordGroup.ts
+++ b/web-ui/src/solver/CoordGroup.ts
@@ -1,5 +1,5 @@
 import { Coord } from './Coord'
-import { SIZE, REGION_SIZE } from './BoardSettings'
+import { SIZE, REGION_SIZE } from './Bitmask'
 
 /**
  * Represents a group of coordinates (row, column, or 3×3 region).

--- a/web-ui/src/solver/Eliminators.ts
+++ b/web-ui/src/solver/Eliminators.ts
@@ -1,0 +1,187 @@
+import type { Board } from './Board'
+import { CoordGroup } from './CoordGroup'
+import { bitCount, MASKS, WILDCARD_PATTERN } from './Bitmask'
+
+// ---------------------------------------------------------------------------
+// CandidateEliminator interface
+// ---------------------------------------------------------------------------
+
+/**
+ * A candidate elimination technique.
+ *
+ * Each eliminator modifies the board in-place, removing or confirming
+ * candidates according to its logical rule. Returns true if any change
+ * was made.
+ */
+export interface CandidateEliminator {
+    /** Human-readable technique name (e.g., "Simple Elimination"). */
+    readonly displayName: string
+
+    /** Apply the elimination rule to the board. Returns true if changed. */
+    eliminate(board: Board): boolean
+}
+
+// ---------------------------------------------------------------------------
+// SimpleCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Removes candidates based on placed (confirmed) values in each group.
+ *
+ * For each confirmed cell in a row/column/box, erase that value from all
+ * other cells in the same group. Repeats until the board stabilises.
+ *
+ * Equivalent to the Kotlin `SimpleCandidateEliminator`.
+ */
+export class SimpleCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Simple Elimination'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            for (const group of CoordGroup.all) {
+                for (const coord of group.coords) {
+                    if (board.isConfirmed(coord)) {
+                        const pattern = board.candidatePattern(coord)
+                        for (const peer of group.coords) {
+                            if (coord !== peer) {
+                                const updated = board.eraseCandidatePattern(peer, pattern)
+                                if (updated) {
+                                    anyUpdate = true
+                                    stable = false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GroupCandidateEliminator (Naked Subsets)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds naked subsets in each group.
+ *
+ * If N cells in a group share the same candidate pattern containing
+ * exactly N candidates, those candidates cannot appear in any other
+ * cell in that group. This covers naked singles, pairs, triples, etc.
+ * Repeats until the board stabilises.
+ *
+ * Equivalent to the Kotlin `GroupCandidateEliminator`.
+ */
+export class GroupCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Naked Subset'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            for (const group of CoordGroup.all) {
+                // Count occurrences of each candidate pattern in the group
+                const countByPattern = new Map<number, number>()
+                for (const coord of group.coords) {
+                    const pat = board.candidatePattern(coord)
+                    countByPattern.set(pat, (countByPattern.get(pat) ?? 0) + 1)
+                }
+
+                // Find patterns where bitCount == occurrence count (naked subset)
+                for (const [pattern, count] of countByPattern) {
+                    const bc = bitCount(pattern)
+                    if (bc === count && bc !== 9) {
+                        // Erase this pattern from all OTHER cells in the group
+                        let updated = false
+                        for (const coord of group.coords) {
+                            if (board.candidatePattern(coord) !== pattern) {
+                                if (board.eraseCandidatePattern(coord, pattern)) {
+                                    updated = true
+                                }
+                            }
+                        }
+                        if (updated) {
+                            anyUpdate = true
+                            stable = false
+                        }
+                    }
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExclusionCandidateEliminator (Hidden Singles)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds hidden singles in each group.
+ *
+ * If a candidate value appears in only one cell within a group, that cell
+ * must hold that value. The cell is marked as confirmed.
+ *
+ * The `shortCircuitThreshold` skips groups that already have enough known
+ * values (optimisation).
+ *
+ * Equivalent to the Kotlin `ExclusionCandidateEliminator`.
+ */
+export class ExclusionCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Hidden Single'
+
+    private readonly shortCircuitThreshold: number
+
+    constructor(shortCircuitThreshold = 8) {
+        this.shortCircuitThreshold = shortCircuitThreshold
+    }
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            for (const group of CoordGroup.all) {
+                // Collect known (confirmed) values in this group
+                const knownValues = new Set<number>()
+                for (const coord of group.coords) {
+                    const v = board.value(coord)
+                    if (v !== 0) knownValues.add(v)
+                }
+
+                // Short-circuit: if enough values are already known, skip
+                if (knownValues.size >= this.shortCircuitThreshold) continue
+
+                // Count occurrences of each candidate value across all cells
+                const valueCount = new Map<number, number>()
+                for (const coord of group.coords) {
+                    const candidates = board.candidateValues(coord)
+                    for (const v of candidates) {
+                        valueCount.set(v, (valueCount.get(v) ?? 0) + 1)
+                    }
+                }
+
+                // Find values that appear exactly once and aren't already placed
+                for (const [value, count] of valueCount) {
+                    if (count === 1 && !knownValues.has(value)) {
+                        // Mark the cell containing this candidate as confirmed
+                        for (const coord of group.coords) {
+                            if (board.candidatePattern(coord) & MASKS[value - 1]) {
+                                board.markValue(coord, value)
+                                anyUpdate = true
+                                stable = false
+                                break
+                            }
+                        }
+                    }
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+}

--- a/web-ui/src/solver/Solver.ts
+++ b/web-ui/src/solver/Solver.ts
@@ -1,0 +1,197 @@
+import type { Board } from './Board'
+import type { CandidateEliminator } from './Eliminators'
+import {
+    SimpleCandidateEliminator,
+    GroupCandidateEliminator,
+    ExclusionCandidateEliminator,
+} from './Eliminators'
+import { Coord } from './Coord'
+
+// ---------------------------------------------------------------------------
+// SolvingListener (minimal)
+// ---------------------------------------------------------------------------
+
+/** Callback interface for observing the solving process. */
+export interface SolvingListener {
+    onPropagationPassStarted?(): void
+    onEliminatorApplied?(techniqueName: string, totalEliminated: number): void
+    onCandidatesEliminated?(techniqueName: string, eliminations: Elimination[]): void
+    onGuessMade?(coord: Coord, firstCandidate: number, totalCandidates: number): void
+    onCellFilled?(coord: Coord, value: number, explanation: string): void
+    onBacktracking?(): void
+    onSolveComplete?(solved: boolean, timeNanos: number, backtracks: number): void
+}
+
+/** Tracks a set of candidate values removed from a specific cell. */
+export interface Elimination {
+    coord: Coord
+    eliminatedValues: number[]
+}
+
+/** No-op listener for when observation is not needed. */
+export const NoOpListener: SolvingListener = {}
+
+// ---------------------------------------------------------------------------
+// SolverConfig
+// ---------------------------------------------------------------------------
+
+/** Configuration for the Sudoku solver. */
+export class SolverConfig {
+    readonly eliminators: readonly CandidateEliminator[]
+    readonly maxRecursionDepth: number
+
+    constructor(
+        eliminators?: readonly CandidateEliminator[],
+        maxRecursionDepth?: number,
+    ) {
+        this.eliminators = eliminators ?? defaultEliminators()
+        this.maxRecursionDepth = maxRecursionDepth ?? 1000
+    }
+
+    /** Factory: only the 3 core eliminators (no advanced techniques). */
+    static basic(): SolverConfig {
+        return new SolverConfig([
+            new SimpleCandidateEliminator(),
+            new GroupCandidateEliminator(),
+            new ExclusionCandidateEliminator(9),
+        ])
+    }
+}
+
+/** Default eliminators: the 3 core techniques. */
+function defaultEliminators(): readonly CandidateEliminator[] {
+    return [
+        new SimpleCandidateEliminator(),
+        new GroupCandidateEliminator(),
+        new ExclusionCandidateEliminator(9),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Solver
+// ---------------------------------------------------------------------------
+
+/**
+ * Main Sudoku solver using constraint propagation and backtracking.
+ *
+ * ## Strategy
+ * 1. **Constraint propagation**: Apply all configured eliminators iteratively
+ *    until no more progress can be made.
+ * 2. **Backtracking**: When propagation stalls, pick the cell with the fewest
+ *    candidates (MRV heuristic) and try each value recursively.
+ *
+ * Equivalent to the Kotlin `Solver` class.
+ */
+export class Solver {
+    private readonly config: SolverConfig
+
+    constructor(config?: SolverConfig) {
+        this.config = config ?? new SolverConfig()
+    }
+
+    /**
+     * Solve a puzzle. Returns the solved board or null if no solution exists.
+     */
+    solve(board: Board, listener: SolvingListener = NoOpListener): Board | null {
+        return this.solveInternal(board, 0, listener)
+    }
+
+    /**
+     * Internal recursive solver with depth tracking.
+     *
+     * @param board The puzzle board to solve (will be mutated in-place).
+     * @param depth Current recursion depth.
+     * @param listener Optional observer.
+     */
+    private solveInternal(board: Board, depth: number, listener: SolvingListener): Board | null {
+        // Safety: prevent infinite recursion
+        if (depth > this.config.maxRecursionDepth) return null
+        if (!board.isValid()) return null
+        if (board.isSolved()) return board
+
+        // Phase 1: Constraint propagation — apply eliminators until stable
+        listener.onPropagationPassStarted?.()
+
+        let anyProgress = true
+        while (anyProgress) {
+            anyProgress = false
+            for (const eliminator of this.config.eliminators) {
+                // Snapshot candidate values for unresolved cells
+                const beforeState = new Map<Coord, Set<number>>()
+                for (const c of Coord.all) {
+                    if (!board.isConfirmed(c)) {
+                        beforeState.set(c, new Set(board.candidateValues(c)))
+                    }
+                }
+
+                const changed = eliminator.eliminate(board)
+                if (changed) {
+                    // Compute per-cell diffs
+                    const eliminations: Elimination[] = []
+                    for (const [coord, beforeValues] of beforeState) {
+                        if (!board.isConfirmed(coord)) {
+                            const afterValues = new Set(board.candidateValues(coord))
+                            const removed = [...beforeValues].filter((v) => !afterValues.has(v))
+                            if (removed.length > 0) {
+                                eliminations.push({ coord, eliminatedValues: removed })
+                            }
+                        } else {
+                            // Cell became confirmed
+                            const confirmedValue = board.value(coord)
+                            const removed = [...beforeValues].filter((v) => v !== confirmedValue)
+                            if (removed.length > 0) {
+                                eliminations.push({ coord, eliminatedValues: removed })
+                            }
+                        }
+                    }
+
+                    const totalEliminated = eliminations.reduce(
+                        (sum, e) => sum + e.eliminatedValues.length,
+                        0,
+                    )
+                    if (totalEliminated > 0) {
+                        listener.onEliminatorApplied?.(eliminator.displayName, totalEliminated)
+                        listener.onCandidatesEliminated?.(eliminator.displayName, eliminations)
+                    }
+                    anyProgress = true
+                }
+            }
+        }
+
+        if (!board.isValid()) return null
+        if (board.isSolved()) return board
+
+        // Phase 2: Backtracking with MRV (Minimum Remaining Values) heuristic
+        const unresolvedCoord = board.unresolvedCoord()
+        if (!unresolvedCoord) return null
+
+        const candidates = board.candidateValues(unresolvedCoord)
+
+        // Multi-candidate = guess point
+        if (candidates.length > 1) {
+            listener.onGuessMade?.(unresolvedCoord, candidates[0], candidates.length)
+        }
+
+        for (const candidateValue of candidates) {
+            const newBoard = board.copy()
+            newBoard.markValue(unresolvedCoord, candidateValue)
+
+            const explanation =
+                candidates.length === 1
+                    ? `Naked Single at (${unresolvedCoord.row + 1}, ${unresolvedCoord.col + 1}) — only candidate is ${candidateValue}`
+                    : `Guess (try ${candidateValue} among ${candidates.length} candidates) at (${unresolvedCoord.row + 1}, ${unresolvedCoord.col + 1})`
+
+            listener.onCellFilled?.(unresolvedCoord, candidateValue, explanation)
+
+            const result = this.solveInternal(newBoard, depth + 1, listener)
+            if (result !== null) {
+                return result
+            }
+
+            // Backtrack
+            listener.onBacktracking?.()
+        }
+
+        return null
+    }
+}


### PR DESCRIPTION
Closes #313

## Part 4 of #272 — Client-side TypeScript Solver

### Depends On
- [ ] #323 — port solver data model (Coord, CoordGroup, Board)
- [ ] #324 — port bitmask utilities and BoardReader
- [ ] #325 — port 3 core eliminators

### Changes
- **`web-ui/src/solver/Solver.ts`** — Complete backtracking solver engine:

  **Solver class:**
  - `solve(board, listener?)` → Board | null
  - Phase 1: Iterative constraint propagation — applies all eliminators until stable
  - Phase 2: MRV backtracking — picks cell with fewest candidates, branches
  - Recursion depth safety cap (default 1000)

  **SolverConfig:**
  - Configurable eliminator list and max recursion depth
  - `basic()` factory with 3 core eliminators

  **SolvingListener interface:**
  - onPropagationPassStarted, onEliminatorApplied, onCandidatesEliminated
  - onGuessMade, onCellFilled, onBacktracking, onSolveComplete
  - Elimination type for per-cell diffs
  - NoOpListener for silent operation

### Implementation notes
- Matches Kotlin solver logic exactly (per-cell snapshot comparison, iterative stabilisation)
- Uses only the 3 core eliminators as default (no advanced techniques yet)
- Board is mutated in-place during solving

### Verification
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] ESLint passes (`--max-warnings 0`)
- [x] Frontend builds (`npm run build`)

### Self-Review
- [x] No unrelated/stray changes
- [x] Static build artifacts reverted
- [x] Branch based on feat/ts-core-eliminators (includes #310 + #311 + #312)