### PR TITLE
fix: upgrade Ktor 2.3.7 → 3.4.3 (Part 1)

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -14,12 +14,12 @@ repositories {
 
 dependencies {
     // Ktor server
-    implementation("io.ktor:ktor-server-core:2.3.7")
-    implementation("io.ktor:ktor-server-netty:2.3.7")
-    implementation("io.ktor:ktor-server-content-negotiation:2.3.7")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.7")
-    implementation("io.ktor:ktor-server-cors:2.3.7")
-    implementation("io.ktor:ktor-server-rate-limit:2.3.7")
+    implementation("io.ktor:ktor-server-core:3.4.3")
+    implementation("io.ktor:ktor-server-netty:3.4.3")
+    implementation("io.ktor:ktor-server-content-negotiation:3.4.3")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:3.4.3")
+    implementation("io.ktor:ktor-server-cors:3.4.3")
+    implementation("io.ktor:ktor-server-rate-limit:3.4.3")
     
     // Kotlinx serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
@@ -31,7 +31,7 @@ dependencies {
     implementation(project(":kotlin"))
     
     // Testing
-    testImplementation("io.ktor:ktor-server-tests:2.3.7")
+    testImplementation("io.ktor:ktor-server-test-host:3.4.3")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:1.9.22")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/web/src/main/kotlin/will/sudoku/web/StepByStepRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/StepByStepRoutes.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.ktor.util.pipeline.*
 import kotlinx.serialization.Serializable
 import will.sudoku.solver.BoardReader
 import will.sudoku.solver.SolverWithSteps
@@ -43,15 +42,15 @@ data class CellCoord(
 )
 
 fun Route.stepByStepRoutes() {
-    post("/solve/steps") { handleSolveSteps() }
-    post("/step-by-step") { handleSolveSteps() }
+    post("/solve/steps") { call.handleSolveSteps() }
+    post("/step-by-step") { call.handleSolveSteps() }
 }
 
-private suspend fun PipelineContext<Unit, ApplicationCall>.handleSolveSteps() {
+private suspend fun ApplicationCall.handleSolveSteps() {
     val request = try {
-        call.receive<SolveStepsRequest>()
+        receive<SolveStepsRequest>()
     } catch (e: Exception) {
-        call.respond(
+        respond(
             HttpStatusCode.BadRequest,
             SolveStepsResponse(
                 solved = false,
@@ -65,7 +64,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.handleSolveSteps() {
 
     // Validate puzzle length
     if (request.puzzle.length != 81) {
-        call.respond(
+        respond(
             HttpStatusCode.BadRequest,
             SolveStepsResponse(
                 solved = false,
@@ -81,7 +80,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.handleSolveSteps() {
     val board = try {
         BoardReader.readBoard(request.puzzle)
     } catch (e: Exception) {
-        call.respond(
+        respond(
             HttpStatusCode.BadRequest,
             SolveStepsResponse(
                 solved = false,
@@ -123,7 +122,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.handleSolveSteps() {
         }
     }
 
-    call.respond(
+    respond(
         SolveStepsResponse(
             solved = progress.isSolved,
             solution = solutionString,


### PR DESCRIPTION
## Summary

Upgrade Ktor from 2.3.7 to 3.4.3 (Part 1 — dependencies + compilation fix).

## Changes
- Update all 6 ktor implementation deps: `2.3.7` → `3.4.3`
- Replace `ktor-server-tests:2.3.7` → `ktor-server-test-host:3.4.3` (renamed in Ktor 3.x)
- Fix `StepByStepRoutes.kt`: `PipelineContext<Unit, ApplicationCall>` → `ApplicationCall` extension (Ktor 3.x removed PipelineContext-based route handlers)

## Test Plan
- [x] `./gradlew test` — all tests pass
- [x] `npm run lint:ci` — clean
- [x] `npm run build` — frontend builds
- [x] `./gradlew :web:installDist` — distribution builds

## Known Follow-ups (Part 2)
Deprecation warnings in `Application.kt`:
- `static()` → `staticFiles()` / `staticResources()`
- `intercept()` → route-scoped plugins

Closes #331