### PR TITLE
feat: port HiddenSubsetCandidateEliminator to TypeScript

### DIFF
--- a/web-ui/src/solver/Eliminators.ts
+++ b/web-ui/src/solver/Eliminators.ts
@@ -1,6 +1,7 @@
 import type { Board } from './Board'
+import { Coord } from './Coord'
 import { CoordGroup } from './CoordGroup'
-import { bitCount, MASKS, WILDCARD_PATTERN } from './Bitmask'
+import { bitCount, MASKS, SIZE, WILDCARD_PATTERN } from './Bitmask'
 
 // ---------------------------------------------------------------------------
 // CandidateEliminator interface
@@ -184,4 +185,123 @@ export class ExclusionCandidateEliminator implements CandidateEliminator {
         } while (!stable)
         return anyUpdate
     }
+}
+
+// ---------------------------------------------------------------------------
+// HiddenSubsetCandidateEliminator (Hidden Pairs, Triples, Quads)
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds hidden subsets within groups.
+ *
+ * A hidden subset occurs when N candidates appear in exactly N cells within a
+ * group, even if those cells also contain other candidates. In this case, all
+ * other candidates can be removed from those N cells.
+ *
+ * Equivalent to the Kotlin `HiddenSubsetCandidateEliminator`.
+ */
+export class HiddenSubsetCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Hidden Subset'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            for (const group of CoordGroup.all) {
+                if (this._eliminateFromGroup(board, group)) {
+                    anyUpdate = true
+                    stable = false
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private _eliminateFromGroup(board: Board, group: CoordGroup): boolean {
+        const candidateToCells = new Map<number, Coord[]>()
+        for (const coord of group.coords) {
+            const candidates = board.candidateValues(coord)
+            for (const c of candidates) {
+                const list = candidateToCells.get(c)
+                if (list) list.push(coord)
+                else candidateToCells.set(c, [coord])
+            }
+        }
+
+        const limited = new Map<number, Coord[]>()
+        for (const [cand, cells] of candidateToCells) {
+            if (cells.length >= 2 && cells.length <= 4) {
+                limited.set(cand, cells)
+            }
+        }
+        if (limited.size < 2) return false
+
+        let anyUpdate = false
+        for (const size of [2, 3, 4]) {
+            if (this._checkSubset(board, limited, size)) {
+                anyUpdate = true
+            }
+        }
+        return anyUpdate
+    }
+
+    private _checkSubset(
+        board: Board,
+        candidateToCells: Map<number, Coord[]>,
+        subsetSize: number,
+    ): boolean {
+        const eligible: number[] = []
+        for (const [cand, cells] of candidateToCells) {
+            if (cells.length <= subsetSize) {
+                eligible.push(cand)
+            }
+        }
+        if (eligible.length < subsetSize) return false
+
+        let anyUpdate = false
+        const combos = combinations(eligible, subsetSize)
+
+        for (const combo of combos) {
+            const cellsWithCandidates = new Set<Coord>()
+            for (const cand of combo) {
+                const cells = candidateToCells.get(cand)
+                if (cells) {
+                    for (const c of cells) cellsWithCandidates.add(c)
+                }
+            }
+
+            if (cellsWithCandidates.size === subsetSize) {
+                const comboMasks = new Set(combo.map(v => MASKS[v - 1]))
+
+                for (const cell of cellsWithCandidates) {
+                    const pat = board.candidatePattern(cell)
+                    for (let i = 0; i < SIZE; i++) {
+                        if ((pat & MASKS[i]) !== 0 && !comboMasks.has(MASKS[i])) {
+                            if (board.eraseCandidateValue(cell, i + 1)) {
+                                anyUpdate = true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+}
+
+function combinations<T>(arr: T[], size: number): T[][] {
+    if (size === 0) return [[]]
+    if (size > arr.length) return []
+    if (size === 1) return arr.map(item => [item])
+
+    const result: T[][] = []
+    for (let i = 0; i <= arr.length - size; i++) {
+        const first = arr[i]
+        const rest = arr.slice(i + 1)
+        for (const combo of combinations(rest, size - 1)) {
+            result.push([first, ...combo])
+        }
+    }
+    return result
 }

--- a/web-ui/src/solver/index.ts
+++ b/web-ui/src/solver/index.ts
@@ -117,6 +117,7 @@ export {
     SimpleCandidateEliminator,
     GroupCandidateEliminator,
     ExclusionCandidateEliminator,
+    HiddenSubsetCandidateEliminator,
 } from './Eliminators'
 export type { CandidateEliminator } from './Eliminators'
 export { SIZE, REGION_SIZE, SYMBOLS, MASKS, WILDCARD_PATTERN, bitCount } from './Bitmask'

--- a/web-ui/tests/solver/HiddenSubset.test.ts
+++ b/web-ui/tests/solver/HiddenSubset.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '@/solver/Board'
+import { BoardReader } from '@/solver/BoardReader'
+import { HiddenSubsetCandidateEliminator } from '@/solver/Eliminators'
+
+describe('HiddenSubsetCandidateEliminator', () => {
+  it('has correct displayName', () => {
+    const eliminator = new HiddenSubsetCandidateEliminator()
+    expect(eliminator.displayName).toBe('Hidden Subset')
+  })
+
+  it('returns false when no hidden subsets exist (empty board)', () => {
+    const puzzle = '.'.repeat(81)
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new HiddenSubsetCandidateEliminator()
+    const changed = eliminator.eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('returns false when board is already fully solved', () => {
+    const puzzle = '534678912672195348198342567859761423426853791713924856961537284287419635345286179'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new HiddenSubsetCandidateEliminator()
+    const changed = eliminator.eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('does not throw on any valid puzzle', () => {
+    const puzzles = [
+      '53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79',
+      '1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5',
+      '.....6....59.....82....8....45........3........6..3.54...325..6..................',
+    ]
+    const eliminator = new HiddenSubsetCandidateEliminator()
+    for (const puzzle of puzzles) {
+      const board = BoardReader.fromString(puzzle, Board)
+      // Should not throw
+      eliminator.eliminate(board)
+    }
+  })
+})


### PR DESCRIPTION
Refs #327

## Part 7a of #272 — port advanced eliminators batch 1

### Changes
Ported `HiddenSubsetCandidateEliminator` from Kotlin to TypeScript, covering **Hidden Pairs, Hidden Triples, and Hidden Quads**.

| File | Change |
|------|--------|
| `src/solver/Eliminators.ts` | Added `HiddenSubsetCandidateEliminator` class (77 lines) + `combinations()` helper (16 lines) |
| `src/solver/index.ts` | Exported `HiddenSubsetCandidateEliminator` |
| `tests/solver/HiddenSubset.test.ts` | 4 tests: displayName, empty board, solved board, stability |

### Algorithm
For each group (row/col/region), finds subsets of N candidates (2 ≤ N ≤ 4) that appear in exactly N cells. Removes all non-subset candidates from those cells. Uses iterative stability until no more hidden subsets are found.

### Verification
- [x] All tests pass (`npx vitest run tests/solver/`)
- [x] TypeScript compiles clean
- [x] ESLint passes (`--max-warnings 0`)
- [x] Frontend builds successfully