### PR TITLE
feat: port Skyscraper eliminator to TypeScript

### DIFF
--- a/web-ui/src/solver/Eliminators.ts
+++ b/web-ui/src/solver/Eliminators.ts
@@ -573,3 +573,124 @@ export class FishCandidateEliminator implements CandidateEliminator {
 }
 
 // ---------------------------------------------------------------------------
+// SkyscraperCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Skyscraper: Find two rows (or two columns) where a candidate appears in
+ * exactly two cells each, with one aligned cell in the same column (for
+ * rows) or row (for columns). The two non-aligned cells can "see" each
+ * other's intersection — eliminate the candidate from any cell that sees
+ * both non-aligned ends.
+ */
+export class SkyscraperCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Skyscraper'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            if (this._skyscraperRows(board)) { anyUpdate = true; stable = false }
+            if (this._skyscraperCols(board)) { anyUpdate = true; stable = false }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    /** Skyscraper across rows (shared column). */
+    private _skyscraperRows(board: Board): boolean {
+        let anyUpdate = false
+        for (let value = 1; value <= SIZE; value++) {
+            const mask = MASKS[value - 1]
+            // Find rows where candidate appears in exactly 2 cells
+            const rowPositions: Map<number, number[]> = new Map()
+            for (let r = 0; r < SIZE; r++) {
+                const cols: number[] = []
+                for (let c = 0; c < SIZE; c++) {
+                    if (board.candidatePattern(Coord.all[r * 9 + c]) & mask) {
+                        cols.push(c)
+                    }
+                }
+                if (cols.length === 2) rowPositions.set(r, cols)
+            }
+            if (rowPositions.size < 2) continue
+
+            const rows = [...rowPositions.keys()]
+            for (let i = 0; i < rows.length; i++) {
+                for (let j = i + 1; j < rows.length; j++) {
+                    const r1 = rows[i], r2 = rows[j]
+                    const cols1 = rowPositions.get(r1)!
+                    const cols2 = rowPositions.get(r2)!
+
+                    // Find shared column
+                    const shared = cols1.filter(c => cols2.includes(c))
+                    if (shared.length !== 1) continue
+                    const sc = shared[0]
+
+                    // Non-shared columns
+                    const c1 = cols1.find(c => c !== sc)!
+                    const c2 = cols2.find(c => c !== sc)!
+
+                    // Eliminate from cells that see both non-aligned ends
+                    // i.e., cells in row r1, col c2 AND row r2, col c1
+                    const targets = [
+                        Coord.all[r1 * 9 + c2],
+                        Coord.all[r2 * 9 + c1],
+                    ]
+                    for (const t of targets) {
+                        if (board.eraseCandidateValue(t, value)) {
+                            anyUpdate = true
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+
+    /** Skyscraper across columns (shared row). */
+    private _skyscraperCols(board: Board): boolean {
+        let anyUpdate = false
+        for (let value = 1; value <= SIZE; value++) {
+            const mask = MASKS[value - 1]
+            const colPositions: Map<number, number[]> = new Map()
+            for (let c = 0; c < SIZE; c++) {
+                const rows: number[] = []
+                for (let r = 0; r < SIZE; r++) {
+                    if (board.candidatePattern(Coord.all[r * 9 + c]) & mask) {
+                        rows.push(r)
+                    }
+                }
+                if (rows.length === 2) colPositions.set(c, rows)
+            }
+            if (colPositions.size < 2) continue
+
+            const cols = [...colPositions.keys()]
+            for (let i = 0; i < cols.length; i++) {
+                for (let j = i + 1; j < cols.length; j++) {
+                    const c1 = cols[i], c2 = cols[j]
+                    const rows1 = colPositions.get(c1)!
+                    const rows2 = colPositions.get(c2)!
+
+                    const shared = rows1.filter(r => rows2.includes(r))
+                    if (shared.length !== 1) continue
+                    const sr = shared[0]
+
+                    const r1 = rows1.find(r => r !== sr)!
+                    const r2 = rows2.find(r => r !== sr)!
+
+                    const targets = [
+                        Coord.all[r1 * 9 + c2],
+                        Coord.all[r2 * 9 + c1],
+                    ]
+                    for (const t of targets) {
+                        if (board.eraseCandidateValue(t, value)) {
+                            anyUpdate = true
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+}

--- a/web-ui/src/solver/index.ts
+++ b/web-ui/src/solver/index.ts
@@ -121,6 +121,7 @@ export {
     PointingCandidateEliminator,
     ClaimingCandidateEliminator,
     FishCandidateEliminator,
+    SkyscraperCandidateEliminator,
 } from './Eliminators'
 export type { CandidateEliminator } from './Eliminators'
 export { SIZE, REGION_SIZE, SYMBOLS, MASKS, WILDCARD_PATTERN, bitCount } from './Bitmask'

--- a/web-ui/tests/solver/Skyscraper.test.ts
+++ b/web-ui/tests/solver/Skyscraper.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '@/solver/Board'
+import { BoardReader } from '@/solver/BoardReader'
+import { SkyscraperCandidateEliminator } from '@/solver/Eliminators'
+
+describe('SkyscraperCandidateEliminator', () => {
+  it('has correct displayName', () => {
+    expect(new SkyscraperCandidateEliminator().displayName).toBe('Skyscraper')
+  })
+
+  it('returns false on empty board', () => {
+    const board = BoardReader.fromString('.'.repeat(81), Board)
+    const changed = new SkyscraperCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('returns false on fully solved board', () => {
+    const solved = '534678912672195348198342567859761423426853791713924856961537284287419635345286179'
+    const board = BoardReader.fromString(solved, Board)
+    const changed = new SkyscraperCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('does not throw on various puzzles', () => {
+    const eliminator = new SkyscraperCandidateEliminator()
+    const puzzles = [
+      '53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79',
+      '1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5',
+      '.....6....59.....82....8....45........3........6..3.54...325..6..................',
+    ]
+    for (const p of puzzles) {
+      const board = BoardReader.fromString(p, Board)
+      eliminator.eliminate(board)
+    }
+  })
+})


### PR DESCRIPTION
Refs #328

## Part 7b of #272 — Skyscraper eliminator

### Changes
Ported **Skyscraper** elimination technique from Kotlin to TypeScript.

### Algorithm
- For each candidate value, find rows (or columns) where the candidate appears in exactly 2 cells
- Find pairs of rows sharing one column (forming the Skyscraper "floor")
- The two non-aligned cells at the "top" can see each other's intersection
- Eliminate candidate from cells that see both non-aligned ends
- Mirrored for column-based Skyscrapers

### Files
| File | Change |
|------|--------|
| `src/solver/Eliminators.ts` | `SkyscraperCandidateEliminator` (105 lines) |
| `src/solver/index.ts` | Export |
| `tests/solver/Skyscraper.test.ts` | 4 tests (displayName, empty, solved, stability) |

### #328 Progress
- ✅ X-Wing / Swordfish / Jellyfish (Fish — PR #340)
- ✅ Skyscraper (PR #341)
- [ ] 2-String Kite
- [ ] Empty Rectangle
- [ ] W-Wing

### Verification
- [x] All tests pass
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] Frontend builds successfully