### PR TITLE
feat: port 2-String Kite eliminator to TypeScript

### DIFF
--- a/web-ui/src/solver/Eliminators.ts
+++ b/web-ui/src/solver/Eliminators.ts
@@ -694,3 +694,98 @@ export class SkyscraperCandidateEliminator implements CandidateEliminator {
         return anyUpdate
     }
 }
+
+// ---------------------------------------------------------------------------
+// TwoStringKiteCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * 2-String Kite: A candidate forms two strong links (one in a row, one in
+ * a column) connected by a box where the candidate appears in 2 cells
+ * (different row & column). The remote ends of the chain eliminate the
+ * candidate from their intersection.
+ */
+export class TwoStringKiteCandidateEliminator implements CandidateEliminator {
+    readonly displayName = '2-String Kite'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+        let stable: boolean
+        do {
+            stable = true
+            for (let value = 1; value <= SIZE; value++) {
+                if (this._eliminateValue(board, value)) {
+                    anyUpdate = true
+                    stable = false
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private _eliminateValue(board: Board, value: number): boolean {
+        const mask = MASKS[value - 1]
+
+        // Build row strong links: rows where candidate appears in exactly 2 cols
+        const rowLinks: Map<number, [number, number]> = new Map()
+        for (let r = 0; r < SIZE; r++) {
+            const cols: number[] = []
+            for (let c = 0; c < SIZE; c++) {
+                if (board.candidatePattern(Coord.all[r * 9 + c]) & mask) cols.push(c)
+            }
+            if (cols.length === 2) rowLinks.set(r, [cols[0], cols[1]])
+        }
+
+        // Build column strong links: cols where candidate appears in exactly 2 rows
+        const colLinks: Map<number, [number, number]> = new Map()
+        for (let c = 0; c < SIZE; c++) {
+            const rows: number[] = []
+            for (let r = 0; r < SIZE; r++) {
+                if (board.candidatePattern(Coord.all[r * 9 + c]) & mask) rows.push(r)
+            }
+            if (rows.length === 2) colLinks.set(c, [rows[0], rows[1]])
+        }
+
+        // Find 2-string kite: a box with 2 candidate cells, one forming
+        // a row strong link, the other a column strong link
+        let anyUpdate = false
+
+        for (const region of CoordGroup.region) {
+            // Find cells in this region with the candidate
+            const regionCells: Coord[] = []
+            for (const coord of region.coords) {
+                if (board.candidatePattern(coord) & mask) regionCells.push(coord)
+            }
+
+            // Need exactly 2 cells, in different rows and columns
+            if (regionCells.length !== 2) continue
+            const a = regionCells[0], b = regionCells[1]
+            if (a.row === b.row || a.col === b.col) continue
+
+            // Try: cell A forms row strong link, cell B forms col strong link
+            if (rowLinks.has(a.row) && colLinks.has(b.col)) {
+                const [ac1, ac2] = rowLinks.get(a.row)!
+                // The row link's other end (not a.col)
+                const rowOtherCol = ac1 === a.col ? ac2 : ac1
+                const [br1, br2] = colLinks.get(b.col)!
+                // The column link's other end (not b.row)
+                const colOtherRow = br1 === b.row ? br2 : br1
+                // Eliminate from intersection of rowOther and colOther
+                const target = Coord.all[colOtherRow * 9 + rowOtherCol]
+                if (board.eraseCandidateValue(target, value)) anyUpdate = true
+            }
+
+            // Try: cell A forms col strong link, cell B forms row strong link
+            if (colLinks.has(a.col) && rowLinks.has(b.row)) {
+                const [ar1, ar2] = colLinks.get(a.col)!
+                const colOtherRow = ar1 === a.row ? ar2 : ar1
+                const [bc1, bc2] = rowLinks.get(b.row)!
+                const rowOtherCol = bc1 === b.col ? bc2 : bc1
+                const target = Coord.all[colOtherRow * 9 + rowOtherCol]
+                if (board.eraseCandidateValue(target, value)) anyUpdate = true
+            }
+        }
+
+        return anyUpdate
+    }
+}

--- a/web-ui/src/solver/index.ts
+++ b/web-ui/src/solver/index.ts
@@ -122,6 +122,7 @@ export {
     ClaimingCandidateEliminator,
     FishCandidateEliminator,
     SkyscraperCandidateEliminator,
+    TwoStringKiteCandidateEliminator,
 } from './Eliminators'
 export type { CandidateEliminator } from './Eliminators'
 export { SIZE, REGION_SIZE, SYMBOLS, MASKS, WILDCARD_PATTERN, bitCount } from './Bitmask'

--- a/web-ui/tests/solver/TwoStringKite.test.ts
+++ b/web-ui/tests/solver/TwoStringKite.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '@/solver/Board'
+import { BoardReader } from '@/solver/BoardReader'
+import { TwoStringKiteCandidateEliminator } from '@/solver/Eliminators'
+
+describe('TwoStringKiteCandidateEliminator', () => {
+  it('has correct displayName', () => {
+    expect(new TwoStringKiteCandidateEliminator().displayName).toBe('2-String Kite')
+  })
+
+  it('returns false on empty board', () => {
+    const board = BoardReader.fromString('.'.repeat(81), Board)
+    const changed = new TwoStringKiteCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('returns false on fully solved board', () => {
+    const solved = '534678912672195348198342567859761423426853791713924856961537284287419635345286179'
+    const board = BoardReader.fromString(solved, Board)
+    const changed = new TwoStringKiteCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('does not throw on various puzzles', () => {
+    const eliminator = new TwoStringKiteCandidateEliminator()
+    const puzzles = [
+      '53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79',
+      '1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5',
+      '.....6....59.....82....8....45........3........6..3.54...325..6..................',
+    ]
+    for (const p of puzzles) {
+      const board = BoardReader.fromString(p, Board)
+      eliminator.eliminate(board)
+    }
+  })
+})


### PR DESCRIPTION
Refs #328

## Part 7b of #272 — 2-String Kite eliminator

### Changes
Ported **2-String Kite** elimination technique to TypeScript.

### Algorithm
1. Build row/column strong links (candidate appears in exactly 2 cells per line)
2. For each 3×3 box: find 2 cells with the candidate (different row & column)
3. One cell must form a row strong link; the other a column strong link
4. The two remote ends of the chain intersect at a cell where the candidate is eliminated
5. Tests both orientations (cell A=row link + cell B=col link, and vice versa)

### Files
| File | Change |
|------|--------|
| `src/solver/Eliminators.ts` | `TwoStringKiteCandidateEliminator` (86 lines) |
| `src/solver/index.ts` | Export |
| `tests/solver/TwoStringKite.test.ts` | 4 tests |

### #328 Progress
- ✅ X-Wing / Swordfish / Jellyfish (Fish — PR #340)
- ✅ Skyscraper (PR #341)
- ✅ 2-String Kite (PR #342)
- [ ] Empty Rectangle
- [ ] W-Wing

### Verification
- [x] All tests pass
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] Frontend builds successfully