### PR TITLE
feat: expose git commit hash in /health endpoint

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
@@ -5,6 +5,7 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
+import java.io.File
 import java.lang.management.ManagementFactory
 import java.lang.management.MemoryMXBean
 import java.lang.management.RuntimeMXBean
@@ -14,6 +15,7 @@ data class HealthResponse(
     val status: String,
     val version: String,
     val timestamp: Long = System.currentTimeMillis(),
+    val gitCommit: String? = null,
     val uptime: UptimeInfo? = null,
     val jvm: JvmInfo? = null,
     val system: SystemInfo? = null
@@ -116,11 +118,20 @@ fun Route.healthRoutes() {
             else -> "OK"
         }
 
+        // Read deployed commit hash (file path from env, default /opt/sudoku/.deploy-commit)
+        val gitCommit = try {
+            val commitFile = File(System.getenv("DEPLOY_COMMIT_FILE") ?: "/opt/sudoku/.deploy-commit")
+            if (commitFile.isFile) commitFile.readText().trim().takeIf { it.isNotEmpty() } else null
+        } catch (_: Exception) {
+            null
+        }
+
         call.respond(
             HttpStatusCode.OK,
             HealthResponse(
                 status = status,
                 version = "1.0.0",
+                gitCommit = gitCommit,
                 uptime = uptimeInfo,
                 jvm = jvmInfo,
                 system = systemInfo


### PR DESCRIPTION
Closes #346

### What
Adds a `gitCommit` field to the `/api/v1/health` response.

### Why
The deploy pipeline needs to verify which commit is running after deployment.

### How
- Reads from file at `DEPLOY_COMMIT_FILE` env var (default: `/opt/sudoku/.deploy-commit`)
- File read in request handler, not at registration time (always reflects latest stamp)
- If file missing/unreadable → `gitCommit: null` (graceful degradation)

### Response example
```json
{
  "status": "OK",
  "version": "1.0.0",
  "gitCommit": "d977eb6...",
  "uptime": {...},
  "jvm": {...},
  "system": {...}
}
```

### Changed
- `web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt` — +11 lines