### PR TITLE
feat: add /deploy-info endpoint for deploy verification

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/Application.kt
+++ b/web/src/main/kotlin/will/sudoku/web/Application.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.minutes
 
 // Import route functions
 import will.sudoku.web.healthRoutes
+import will.sudoku.web.deployInfoRoutes
 import will.sudoku.web.solveRoutes
 import will.sudoku.web.hintRoutes
 import will.sudoku.web.generateRoutes
@@ -124,6 +125,7 @@ fun Application.module() {
             }
             
             healthRoutes()
+            deployInfoRoutes()
             solveRoutes()
             hintRoutes()
             generateRoutes()
@@ -147,6 +149,7 @@ fun Application.module() {
             }
             
             healthRoutes()
+            deployInfoRoutes()
             solveRoutes()
             hintRoutes()
             generateRoutes()

--- a/web/src/main/kotlin/will/sudoku/web/DeployInfoRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DeployInfoRoutes.kt
@@ -1,0 +1,59 @@
+package will.sudoku.web
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import java.io.File
+
+/**
+ * Lightweight deploy-info endpoint for monitoring and deploy verification.
+ * Returns version, commit hash, and build timestamp without heavy system metrics.
+ */
+@Serializable
+data class DeployInfoResponse(
+    val version: String,
+    val gitCommit: String?,
+    val buildTimestamp: String?
+)
+
+/**
+ * Read the deployed git commit hash from a file.
+ * Path is configurable via DEPLOY_COMMIT_FILE env var (default: /opt/sudoku/.deploy-commit).
+ * Returns null if the file is missing or unreadable (graceful degradation).
+ */
+internal fun readGitCommit(): String? {
+    return try {
+        val commitFile = File(System.getenv("DEPLOY_COMMIT_FILE") ?: "/opt/sudoku/.deploy-commit")
+        if (commitFile.isFile) commitFile.readText().trim().takeIf { it.isNotEmpty() } else null
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Read build timestamp from a file placed by the build pipeline.
+ * Returns null if the file is missing or unreadable.
+ */
+internal fun readBuildTimestamp(): String? {
+    return try {
+        val timestampFile = File(System.getenv("BUILD_TIMESTAMP_FILE") ?: "/opt/sudoku/.build-timestamp")
+        if (timestampFile.isFile) timestampFile.readText().trim().takeIf { it.isNotEmpty() } else null
+    } catch (_: Exception) {
+        null
+    }
+}
+
+fun Route.deployInfoRoutes() {
+    get("/deploy-info") {
+        call.respond(
+            HttpStatusCode.OK,
+            DeployInfoResponse(
+                version = "1.0.0",
+                gitCommit = readGitCommit(),
+                buildTimestamp = readBuildTimestamp()
+            )
+        )
+    }
+}


### PR DESCRIPTION
Refs #348 (item 2)

### What
Adds a lightweight `/api/v1/deploy-info` endpoint for monitoring and deploy verification.

### Response
```json
GET /api/v1/deploy-info
{
  "version": "1.0.0",
  "gitCommit": "d977eb6...",
  "buildTimestamp": "2026-05-08T14:00:00Z"
}
```

### Design
- **No heavy metrics** — unlike /health, this endpoint is fast and cheap
- Reads `gitCommit` from `DEPLOY_COMMIT_FILE` (default `/opt/sudoku/.deploy-commit`), same as the upcoming health change
- Reads `buildTimestamp` from `BUILD_TIMESTAMP_FILE` (default `/opt/sudoku/.build-timestamp`)
- Graceful: returns `null` for missing/unreadable files
- Registered on both v1 and legacy paths

### Changed
- `web/src/main/kotlin/will/sudoku/web/DeployInfoRoutes.kt` — new file
- `web/src/main/kotlin/will/sudoku/web/Application.kt` — +2 route registrations