### PR TITLE
feat: build-time version injection via Gradle

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -12,6 +12,52 @@ repositories {
     mavenCentral()
 }
 
+// ============================================================
+// Build-time version injection
+// Generates version.properties with git commit hash and build
+// timestamp, which is then bundled into the classpath.
+// ============================================================
+val generateVersionProperties by tasks.registering {
+    val outputDir = layout.buildDirectory.dir("generated/version")
+    val versionProperties = outputDir.map { it.file("version.properties") }
+
+    inputs.property("buildTime", System.currentTimeMillis())
+    outputs.file(versionProperties)
+
+    doLast {
+        val gitCommit = try {
+            val proc = ProcessBuilder("git", "rev-parse", "--short", "HEAD")
+                .directory(project.rootDir)
+                .redirectErrorStream(true)
+                .start()
+            proc.inputStream.bufferedReader().readText().trim().takeIf { it.isNotEmpty() && !it.contains("fatal:") }
+        } catch (_: Exception) {
+            null
+        }
+        val buildTime = System.currentTimeMillis()
+
+        val outputFile = versionProperties.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText("""
+            gitCommit=${gitCommit ?: "unknown"}
+            buildTime=${buildTime}
+        """.trimIndent())
+    }
+}
+
+// Wire generated properties into processResources
+sourceSets {
+    main {
+        resources {
+            srcDir(layout.buildDirectory.dir("generated/version"))
+        }
+    }
+}
+
+tasks.processResources {
+    dependsOn(generateVersionProperties)
+}
+
 dependencies {
     // Ktor server
     implementation("io.ktor:ktor-server-core:3.4.3")

--- a/web/src/main/kotlin/will/sudoku/web/VersionInfo.kt
+++ b/web/src/main/kotlin/will/sudoku/web/VersionInfo.kt
@@ -1,0 +1,39 @@
+package will.sudoku.web
+
+import java.io.InputStream
+import java.util.Properties
+
+/**
+ * Provides build-time version information from version.properties on the classpath.
+ *
+ * version.properties is generated at build time by Gradle (processResources task)
+ * and contains:
+ *   - gitCommit: short commit hash (or "unknown" if git is unavailable)
+ *   - buildTime: epoch millis when the build ran
+ */
+object VersionInfo {
+    private val props: Properties by lazy {
+        val p = Properties()
+        try {
+            val stream: InputStream? = javaClass.classLoader.getResourceAsStream("version.properties")
+            if (stream != null) {
+                p.load(stream)
+                stream.close()
+            }
+        } catch (_: Exception) {
+            // Properties remain empty
+        }
+        p
+    }
+
+    /** Short git commit hash at build time, or null if unavailable. */
+    val gitCommit: String?
+        get() {
+            val v = props.getProperty("gitCommit")
+            return if (v.isNullOrBlank() || v == "unknown") null else v
+        }
+
+    /** Build timestamp (epoch millis), or null if unavailable. */
+    val buildTime: Long?
+        get() = props.getProperty("buildTime")?.toLongOrNull()
+}


### PR DESCRIPTION
Refs #348 (item 3)

### What
Embeds git commit hash and build timestamp into the application via a classpath resource (`version.properties`), generated at build time.

### Why
- No runtime dependency on external files like `/opt/sudoku/.deploy-commit`
- Works in any environment (local dev, Render, Docker)
- `VersionInfo` utility can be used by any route handler

### How
- `generateVersionProperties` Gradle task runs `git rev-parse --short HEAD`
- Wired into `processResources`, bundled into the final JAR
- `VersionInfo` object reads from classpath (lazy, null-safe)
- Falls back to `null` when properties unavailable

### Generated output (version.properties)
```properties
gitCommit=8d9f269
buildTime=1778250991408
```

### Changed
- `web/build.gradle.kts` — +46 lines (task + sourceSet wiring)
- `web/src/main/kotlin/will/sudoku/web/VersionInfo.kt` — new utility