### PR TITLE
fix: add technique/cell/value fields to step-by-step API response

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/StepByStepRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/StepByStepRoutes.kt
@@ -32,7 +32,10 @@ data class StepResponse(
     val affectedCells: List<CellCoord>,
     val values: List<Int>,
     val explanation: String,
-    val boardState: String? = null
+    val boardState: String? = null,
+    val technique: String? = null,
+    val cell: CellCoord? = null,
+    val value: Int? = null
 )
 
 @Serializable
@@ -102,7 +105,10 @@ private suspend fun ApplicationCall.handleSolveSteps() {
             affectedCells = step.affectedCells.map { CellCoord(it.row, it.col) },
             values = step.values.toList(),
             explanation = step.explanation,
-            boardState = step.boardState
+            boardState = step.boardState,
+            technique = step.stepType.displayName,
+            cell = step.affectedCells.firstOrNull()?.let { CellCoord(it.row, it.col) },
+            value = step.values.firstOrNull()
         )
     }
 


### PR DESCRIPTION
Closes #353

### Problem
The `/api/v1/step-by-step` response had `stepType`, `affectedCells`, `values` fields but clients expected `technique`, `cell`, `value` field names, resulting in `?` for all three.

### Fix
Added `technique`, `cell`, `value` as additional serialized fields:
- `technique` = `stepType.displayName` (same as stepType)
- `cell` = first affected cell or null
- `value` = first value or null

Existing fields preserved for backward compatibility.

### Changed
- `web/src/main/kotlin/will/sudoku/web/StepByStepRoutes.kt` — +8 lines