### PR TITLE
fix: naked-single tutorial step 3 stop highlighting filled cells

### DIFF
--- a/web/src/main/resources/tutorials/lessons.json
+++ b/web/src/main/resources/tutorials/lessons.json
@@ -28,18 +28,10 @@
         "order": 3,
         "type": "highlight",
         "cells": [
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
+          20
         ],
         "highlightColor": "blue",
-        "text": "Let's look at row 3 (highlighted in blue). It already has 1, 3, 4, 5, 6, 7, 9 filled in. Only ONE number is missing!"
+        "text": "Look at R3C3. Its row already has 1, 3, 4, 5, 6, 7, and 9 filled in. Its column has 5, and its box has 2. After eliminating all those, only TWO numbers remain as candidates."
       },
       {
         "order": 4,


### PR DESCRIPTION
Refs #354

### Problem
Step 3 highlighted the entire row 3 including 8 filled cells (1,9,3,4,2,5,6,7) to show row context. This made filled cells appear as highlighted candidates.

### Solution
- Highlight only R3C3 (the empty cell where the naked single is found)
- Updated text to reference the row/column/box values inline: 
  *"Its row already has 1, 3, 4, 5, 6, 7, and 9 filled in. Its column has 5, and its box has 2."*

### Changed
- 1 line changed in `lessons.json` (step 3 cells: 9 → 1)