### PR TITLE
fix: stop 4 more tutorials from highlighting already-filled cells

### DIFF
--- a/web/src/main/resources/tutorials/lessons.json
+++ b/web/src/main/resources/tutorials/lessons.json
@@ -28,18 +28,10 @@
         "order": 3,
         "type": "highlight",
         "cells": [
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26
+          20
         ],
         "highlightColor": "blue",
-        "text": "Let's look at row 3 (highlighted in blue). It already has 1, 3, 4, 5, 6, 7, 9 filled in. Only ONE number is missing!"
+        "text": "Look at R3C3. Its row already has 1, 3, 4, 5, 6, 7, and 9 filled in. Its column has 5, and its box has 2. After eliminating all those, only TWO numbers remain as candidates."
       },
       {
         "order": 4,
@@ -191,7 +183,6 @@
           0,
           3,
           4,
-          5,
           6,
           7
         ],
@@ -734,8 +725,7 @@
         "order": 4,
         "type": "highlight",
         "cells": [
-          22,
-          58
+          22
         ],
         "highlightColor": "yellow",
         "text": "These two cells are our pincers — one shares candidate A with the pivot, the other shares B. Both also contain a common candidate C."
@@ -750,8 +740,7 @@
         "order": 6,
         "type": "reveal",
         "cells": [
-          22,
-          58
+          22
         ],
         "highlightColor": "green",
         "text": "🎉 XY-Wing is powerful! Find the pivot with 2 candidates, locate the pincers, then eliminate from cells seeing both pincers.",
@@ -806,9 +795,7 @@
         "order": 6,
         "type": "reveal",
         "cells": [
-          0,
-          6,
-          12
+          0
         ],
         "highlightColor": "green",
         "text": "🎉 XYZ-Wing extends XY-Wing logic. Master both and you have a powerful toolkit for eliminating candidates in tough puzzles!",


### PR DESCRIPTION
Refs #354

### Fixed (second batch)
- **naked-single**: step 3 now highlights only R3C3 instead of entire filled row 3
- **naked-pair**: step 4 removed R1C6=1 (filled) from elimination highlight
- **xy-wing**: steps 4+6 removed R7C5=7 (filled) from pincer highlights (note: puzzle lacks real XY-wing — full rewrite needs new puzzle)
- **xyz-wing**: step 6 removed R1C7=9 and R2C4=2 (both filled) from reveal

### Progress
- 7 of 13 offending tutorials fixed (covered by PRs #357, #358, #359, #360)
- 34 violations remaining across 8 tutorials (hidden-pair, box-line-reduction, swordfish, als-xz, franken-fish, mutant-fish, death-blossom, forcing-chains)