### PR TITLE
fix: hint returns Naked Single instead of Puzzle Complete for easy puzzles

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
@@ -76,6 +76,35 @@ fun Route.hintRoutes() {
 
         val board = rawBoard.withConstraintPropagation()
         
+        // If constraint propagation fully solved the board but the raw board wasn't solved,
+        // the puzzle is solvable by basic techniques alone. Find the first empty cell
+        // that CP solved and hint at it as a Naked Single instead of reporting "Puzzle Complete".
+        // This prevents the misleading "Puzzle Complete" message on unsolved easy puzzles.
+        if (board.isSolved() && !rawBoard.isSolved()) {
+            for (row in 0..8) {
+                for (col in 0..8) {
+                    val coord = will.sudoku.solver.Coord(row, col)
+                    if (rawBoard.value(coord) == 0 && board.value(coord) != 0) {
+                        val value = board.value(coord)
+                        return@post call.respond(
+                            HintResponse(
+                                type = HintType.NAKED_SINGLE.name,
+                                cell = CellCoordinate(row, col),
+                                technique = "Naked Single",
+                                explanation = "Cell (${row + 1}, ${col + 1}) can only be $value! " +
+                                    "Check the row, column, and box — every other number is already taken.",
+                                teachingPoints = listOf(
+                                    "Look at row ${row + 1}, column ${col + 1}, and the 3x3 box",
+                                    "Only one number is possible in this cell",
+                                    "Easy puzzles can often be solved entirely this way!"
+                                )
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        
         // Map requested technique string to HintGenerator.Technique enum
         val targetTechnique = request.technique?.let { techName ->
             HintGenerator.Technique.entries.find {


### PR DESCRIPTION
Closes #224

### Problem
Easy/medium generated puzzles return `technique: "Puzzle Complete"` with `cell: null` even when the puzzle has 35-45 empty cells. This is worse than the original bug (generic "Scanning") because it falsely tells the player the puzzle is done.

### Root Cause
Constraint propagation cascades through easy puzzles and fully solves the board. The `TeachingHintProvider` receives a fully-solved board, finds no techniques, and falls through to the COMPLETE case — even though the player's raw board isn't solved.

### Fix
In `HintRoutes.kt`, detect when CP solves the board but the raw board isn't solved:
- Compare raw board vs CP board cell-by-cell
- Find the first cell that was empty in raw but now has a value
- Return a `Naked Single` hint pointing to that cell with the solved value

This ensures players always get an actionable cell+value hint instead of the misleading "Puzzle Complete".

### Testing
- `./gradlew test` — all pass
- `./gradlew :web:installDist` — builds clean