### PR TITLE
fix: add missing permissions to Detekt workflow

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -24,6 +24,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 env:
   # Release tag associated with version of Detekt to be installed
   # SARIF support (required for this workflow) was introduced in Detekt v1.15.0


### PR DESCRIPTION
## Problem

The Detekt CI workflow (`Scan with Detekt`) has been failing on every push to master. The `upload-sarif` step errors with:

```
Resource not accessible by integration
```

This is because the workflow lacks the `security-events: write` permission needed by `github/codeql-action/upload-sarif@v3`.

## Fix

Added an explicit `permissions` block:
```yaml
permissions:
  contents: read
  security-events: write
```

## Changes
- `.github/workflows/detekt-analysis.yml` — added permissions block

## Testing
- ✅ `./gradlew test` passes (all 389 tests)
- Workflow change only — no app code affected

Refs #363