### PR TITLE
fix: tutorial complete 500 error + invalid daily puzzle + mapOf serialization

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/DailyChallengeRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DailyChallengeRoutes.kt
@@ -47,7 +47,7 @@ fun Route.dailyChallengeRoutes() {
         // Expert
         ".345.....8.2.6.4..6....8.....39....4.5.....9.9....58.....3....8..1.4.6.5.....712." to "expert",
         "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4.." to "expert",
-        ".....57.....9.1......38.....6...2...4.9..5...7..1....3.2.....8....4..3......1..9." to "expert",
+        ".....6....59.....82....8....45........3........6..3.54...325..6.................." to "expert",
         "000000004760010050090002081070050010000709000080030060240100070010090045900000000".replace('0', '.') to "expert",
         // More variety
         "100000569402000008050009040000640801000010000208035000040500010900000402621000005".replace('0', '.') to "hard",
@@ -72,7 +72,7 @@ fun Route.dailyChallengeRoutes() {
         val board: Board = try {
             BoardReader.readBoard(puzzleStr)
         } catch (e: Exception) {
-            call.respond(HttpStatusCode.InternalServerError, mapOf("error" to "Failed to load daily puzzle"))
+            call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Failed to load daily puzzle"))
             return@get
         }
 
@@ -103,7 +103,7 @@ fun Route.dailyChallengeRoutes() {
     get("/daily/{date}") {
         val dateStr = call.parameters["date"] ?: ""
         val date = try { LocalDate.parse(dateStr) } catch (e: Exception) {
-            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid date format. Use YYYY-MM-DD"))
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid date format. Use YYYY-MM-DD"))
             return@get
         }
 
@@ -114,7 +114,7 @@ fun Route.dailyChallengeRoutes() {
         val board: Board = try {
             BoardReader.readBoard(puzzleStr)
         } catch (e: Exception) {
-            call.respond(HttpStatusCode.InternalServerError, mapOf("error" to "Failed to load puzzle"))
+            call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Failed to load puzzle"))
             return@get
         }
 

--- a/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DifficultyRoutes.kt
@@ -62,7 +62,7 @@ fun Route.difficultyRoutes() {
     get("/generate/difficulty/{level}") {
         val level = call.parameters["level"] ?: return@get call.respond(
             HttpStatusCode.BadRequest,
-            mapOf("error" to "Missing difficulty level")
+            ErrorResponse("Missing difficulty level")
         )
         
         val difficulty = try {
@@ -70,7 +70,7 @@ fun Route.difficultyRoutes() {
         } catch (e: IllegalArgumentException) {
             return@get call.respond(
                 HttpStatusCode.BadRequest,
-                mapOf("error" to "Invalid difficulty level: $level")
+                ErrorResponse("Invalid difficulty level: $level")
             )
         }
         

--- a/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
@@ -52,7 +52,7 @@ fun Route.hintRoutes() {
         } catch (e: Exception) {
             return@post call.respond(
                 HttpStatusCode.BadRequest,
-                mapOf("error" to "Invalid puzzle: ${e.message}")
+                ErrorResponse("Invalid puzzle: ${e.message}")
             )
         }
 

--- a/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
@@ -98,6 +98,12 @@ data class PracticePuzzle(
 )
 
 @Serializable
+data class CompletionResponse(val status: String, val lesson: String, val completed: Boolean)
+
+@Serializable
+data class ErrorResponse(val error: String)
+
+@Serializable
 data class PracticeSet(
     val id: String,
     val technique: String,
@@ -155,7 +161,7 @@ fun Route.tutorialRoutes() {
         val id = call.parameters["id"] ?: ""
         val lesson = lessonsById[id]
         if (lesson == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Tutorial not found: $id"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Tutorial not found: $id"))
             return@get
         }
         call.respond(lesson)
@@ -166,14 +172,14 @@ fun Route.tutorialRoutes() {
         val id = call.parameters["id"] ?: ""
         val lesson = lessonsById[id]
         if (lesson == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Tutorial not found: $id"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Tutorial not found: $id"))
             return@get
         }
 
         val board: Board = try {
             BoardReader.readBoard(lesson.examplePuzzle)
         } catch (e: Exception) {
-            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid puzzle: ${e.message}"))
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid puzzle: ${e.message}"))
             return@get
         }
 
@@ -203,9 +209,9 @@ fun Route.tutorialRoutes() {
         val id = call.parameters["id"] ?: ""
         if (lessonsById.containsKey(id)) {
             completedTutorials[id] = true
-            call.respond(mapOf("status" to "ok", "lesson" to id, "completed" to true))
+            call.respond(CompletionResponse("ok", id, true))
         } else {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Tutorial not found: $id"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Tutorial not found: $id"))
         }
     }
 
@@ -245,7 +251,7 @@ fun Route.tutorialRoutes() {
         val belt = call.parameters["belt"] ?: ""
         val quiz = quizzesByBelt[belt]
         if (quiz == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Quiz not found for belt: $belt"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Quiz not found for belt: $belt"))
             return@get
         }
         call.respond(quiz)
@@ -256,20 +262,20 @@ fun Route.tutorialRoutes() {
         val belt = call.parameters["belt"] ?: ""
         val quiz = quizzesByBelt[belt]
         if (quiz == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Quiz not found for belt: $belt"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Quiz not found for belt: $belt"))
             return@get
         }
 
         val question = quiz.questions.firstOrNull()
         if (question == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "No questions in quiz"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("No questions in quiz"))
             return@get
         }
 
         val board: Board = try {
             BoardReader.readBoard(question.puzzle)
         } catch (e: Exception) {
-            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid puzzle: ${e.message}"))
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid puzzle: ${e.message}"))
             return@get
         }
 
@@ -302,7 +308,7 @@ fun Route.tutorialRoutes() {
         val tutorialId = call.parameters["tutorialId"] ?: ""
         val set = practiceByTutorialId[tutorialId]
         if (set == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Practice puzzles not found for: $tutorialId"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Practice puzzles not found for: $tutorialId"))
             return@get
         }
         call.respond(set)
@@ -314,20 +320,20 @@ fun Route.tutorialRoutes() {
         val puzzleId = call.parameters["puzzleId"] ?: ""
         val set = practiceByTutorialId[tutorialId]
         if (set == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Practice set not found for: $tutorialId"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Practice set not found for: $tutorialId"))
             return@get
         }
 
         val puzzleData = set.puzzles.find { it.id == puzzleId }
         if (puzzleData == null) {
-            call.respond(HttpStatusCode.NotFound, mapOf("error" to "Puzzle not found: $puzzleId"))
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Puzzle not found: $puzzleId"))
             return@get
         }
 
         val board: Board = try {
             BoardReader.readBoard(puzzleData.puzzle)
         } catch (e: Exception) {
-            call.respond(HttpStatusCode.BadRequest, mapOf("error" to "Invalid puzzle: ${e.message}"))
+            call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid puzzle: ${e.message}"))
             return@get
         }
 


### PR DESCRIPTION
## Fixes
- **#372** — POST /tutorials/{id}/complete returned 500 due to mapOf with mixed types (String + Boolean). Added @Serializable data classes (CompletionResponse, ErrorResponse).
- **#374** — Daily challenge crashed on ~24 days/year due to invalid puzzle at index 10 (duplicate values in column 6). Replaced with valid, solver-verified expert puzzle.
- Also replaced all mapOf("error" to ...) in TutorialRoutes, HintRoutes, DailyChallengeRoutes, DifficultyRoutes with typed ErrorResponse.

## Testing
- ✅ ./gradlew test — all 390 tests pass
- ✅ Replacement daily puzzle verified solvable by the engine

Refs #372 Refs #374