### PR TITLE
fix: register celebration routes in Application.kt (#373)

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/Application.kt
+++ b/web/src/main/kotlin/will/sudoku/web/Application.kt
@@ -28,6 +28,7 @@ import will.sudoku.web.dailyChallengeRoutes
 import will.sudoku.web.dashboardRoutes
 import will.sudoku.web.progressRoutes
 import will.sudoku.web.difficultyRoutes
+import will.sudoku.web.celebrationRoutes
 
 fun main() {
     val port = System.getenv("PORT")?.toInt() ?: 8080
@@ -137,6 +138,7 @@ fun Application.module() {
             dashboardRoutes()
             progressRoutes()
             difficultyRoutes()
+            celebrationRoutes()
         }
         
         // Legacy routes (unversioned) - DEPRECATED, will be removed in v2
@@ -161,6 +163,7 @@ fun Application.module() {
             dashboardRoutes()
             progressRoutes()
             difficultyRoutes()
+            celebrationRoutes()
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the celebration endpoint returning 404 by registering `celebrationRoutes()` in `Application.kt`.

The `CelebrationRoutes.kt` file existed with a working implementation, but was never imported or registered in the routing configuration.

### Changes
- Added `import will.sudoku.web.celebrationRoutes`
- Added `celebrationRoutes()` to both `/api/v1` and legacy `/api` route blocks

### Not addressed
The undo-redo routes (`/api/v1/undo-redo/*`) from #373 still need implementation — no backend route file exists for them. This PR only fixes the celebration endpoint.

Refs #373