### PR TITLE
fix: return HTTP 200 instead of 400 for invalid/unsolvable puzzles (#376)

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/PuzzleValidator.kt
+++ b/web/src/main/kotlin/will/sudoku/web/PuzzleValidator.kt
@@ -142,11 +142,14 @@ object PuzzleValidator {
      * Get HTTP status code for validation error.
      */
     fun getHttpStatusCode(errorCode: String): HttpStatusCode {
+        // Return 200 for all validation errors — the response body already
+        // indicates the problem via "solved: false" and the error field.
+        // Returning 400 forces the frontend to handle both error paths.
         return when (errorCode) {
-            "NULL_INPUT", "INVALID_LENGTH", "INVALID_CHARACTERS" -> HttpStatusCode.BadRequest
-            "EMPTY_PUZZLE", "TOO_FEW_CLUES" -> HttpStatusCode.BadRequest
-            "DUPLICATE_VALUES", "STRUCTURAL_CONFLICT" -> HttpStatusCode.BadRequest
-            else -> HttpStatusCode.BadRequest
+            "NULL_INPUT", "INVALID_LENGTH", "INVALID_CHARACTERS" -> HttpStatusCode.OK
+            "EMPTY_PUZZLE", "TOO_FEW_CLUES" -> HttpStatusCode.OK
+            "DUPLICATE_VALUES", "STRUCTURAL_CONFLICT" -> HttpStatusCode.OK
+            else -> HttpStatusCode.OK
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #376 — solve/validate endpoints now return HTTP 200 for invalid/unsolvable puzzles instead of 400.

### Problem
`POST /api/v1/solve` and `POST /api/v1/validate` returned HTTP 400 when given puzzles like "all 1s". While technically correct, this forced the frontend to handle both error responses (4xx) and normal responses (200) in separate code paths. The response body already indicates the problem via `solved: false` / `valid: false` and the `error` field.

### Changes
- `PuzzleValidator.getHttpStatusCode()` now returns `HttpStatusCode.OK` for all validation errors (duplicate values, structural conflicts, empty puzzle, too few clues, etc.)
- Malformed HTTP requests (bad JSON body) still return 400 as appropriate

### Before
```
curl -X POST /api/v1/solve -d {puzzle:111...111}
→ HTTP 400 {"solved":false,"error":"Digit '1' appears 81 times..."}
```

### After
```
curl -X POST /api/v1/solve -d {puzzle:111...111}
→ HTTP 200 {"solved":false,"error":"Digit '1' appears 81 times..."}
```

Refs #376