### PR TITLE
fix: normalize quiz puzzle empty-cell format from . to 0

### DIFF
--- a/web/src/main/resources/tutorials/quizzes.json
+++ b/web/src/main/resources/tutorials/quizzes.json
@@ -3,7 +3,7 @@
     "id": "quiz-white",
     "belt": "white",
     "beltName": "White Belt",
-    "beltEmoji": "⬜",
+    "beltEmoji": "\u2b1c",
     "beltColor": "#E0E0E0",
     "technique": "Naked Single",
     "questions": [
@@ -14,19 +14,39 @@
         "hint": "Look at row 5. Find a cell where all other numbers 1-9 are already present in the row, column, or box, leaving just one possibility.",
         "answerCell": 40,
         "answerValue": "5",
-        "explanation": "Cell R5C5 is a Naked Single with value 5. Every other digit (1-9 except 5) already appears in its row (row 5), column (column 5), or 3×3 box (center box), so 5 is the only possible candidate.",
-        "highlightCells": [36, 37, 38, 39, 40, 41, 42, 43, 44],
+        "explanation": "Cell R5C5 is a Naked Single with value 5. Every other digit (1-9 except 5) already appears in its row (row 5), column (column 5), or 3\u00d73 box (center box), so 5 is the only possible candidate.",
+        "highlightCells": [
+          36,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44
+        ],
         "highlightColor": "blue"
       },
       {
         "id": "white-q2",
         "puzzle": "530070000600195000098000060800060003400803001700020006060000280000419005000080079",
         "question": "Find another Naked Single in the bottom-right area. Which cell has just one possible value?",
-        "hint": "Check the 3×3 box in the bottom-right corner for a cell where every other number is already eliminated by its row, column, and box.",
+        "hint": "Check the 3\u00d73 box in the bottom-right corner for a cell where every other number is already eliminated by its row, column, and box.",
         "answerCell": 70,
         "answerValue": "3",
-        "explanation": "Cell R8C8 is a Naked Single with value 3. All 8 other digits appear in the same row, column, or 3×3 box, leaving 3 as the only possibility.",
-        "highlightCells": [63, 64, 65, 66, 67, 68, 69, 70, 71],
+        "explanation": "Cell R8C8 is a Naked Single with value 3. All 8 other digits appear in the same row, column, or 3\u00d73 box, leaving 3 as the only possibility.",
+        "highlightCells": [
+          63,
+          64,
+          65,
+          66,
+          67,
+          68,
+          69,
+          70,
+          71
+        ],
         "highlightColor": "green"
       }
     ]
@@ -35,7 +55,7 @@
     "id": "quiz-yellow",
     "belt": "yellow",
     "beltName": "Yellow Belt",
-    "beltEmoji": "🟡",
+    "beltEmoji": "\ud83d\udfe1",
     "beltColor": "#FFD700",
     "technique": "Hidden Single",
     "questions": [
@@ -46,8 +66,18 @@
         "hint": "Check which cells in row 6 can hold the number 3. Only ONE cell works because the others are blocked by columns or boxes already containing 3.",
         "answerCell": 47,
         "answerValue": "3",
-        "explanation": "Cell R6C3 is a Hidden Single for value 3 in row 6. No other empty cell in that row can hold 3 — columns 1, 2, 4, and 5 already have 3 in other rows, and the box constraints eliminate the rest.",
-        "highlightCells": [45, 46, 47, 48, 49, 50, 51, 52, 53],
+        "explanation": "Cell R6C3 is a Hidden Single for value 3 in row 6. No other empty cell in that row can hold 3 \u2014 columns 1, 2, 4, and 5 already have 3 in other rows, and the box constraints eliminate the rest.",
+        "highlightCells": [
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          51,
+          52,
+          53
+        ],
         "highlightColor": "blue"
       },
       {
@@ -58,7 +88,17 @@
         "answerCell": 22,
         "answerValue": "4",
         "explanation": "Cell R3C5 is a Hidden Single for value 4 in column 5. Every other empty cell in column 5 is blocked from holding 4 by the row or box already containing that digit.",
-        "highlightCells": [4, 13, 22, 31, 40, 49, 58, 67, 76],
+        "highlightCells": [
+          4,
+          13,
+          22,
+          31,
+          40,
+          49,
+          58,
+          67,
+          76
+        ],
         "highlightColor": "green"
       }
     ]
@@ -67,30 +107,36 @@
     "id": "quiz-orange",
     "belt": "orange",
     "beltName": "Orange Belt",
-    "beltEmoji": "🟠",
+    "beltEmoji": "\ud83d\udfe0",
     "beltColor": "#FF8C00",
     "technique": "Naked Pair",
     "questions": [
       {
         "id": "orange-q1",
-        "puzzle": "...4....8486...72...268.3.4...2.56.31237.849....3..18.2....3.5..3895..4..5..2....",
+        "puzzle": "000400008486000720002680304000205603123708490000300180200003050038950040050020000",
         "question": "Find the Naked Pair in this puzzle. Which two cells share exactly the same two candidates in a column?",
-        "hint": "Look for two cells in the same column that both have only two candidates — and they're the same two numbers.",
+        "hint": "Look for two cells in the same column that both have only two candidates \u2014 and they're the same two numbers.",
         "answerCell": 57,
         "answerValue": "",
         "explanation": "Cells R7C4 and R9C4 form a Naked Pair with candidates {1, 8}. Since these are the only two cells in column 4 that can hold 1 and 8, these values are locked to those cells and can be eliminated from other cells in the column.",
-        "highlightCells": [57, 75],
+        "highlightCells": [
+          57,
+          75
+        ],
         "highlightColor": "yellow"
       },
       {
         "id": "orange-q2",
         "puzzle": "004600010010003005030800002600000400000050000005000003700004020800300060090020008",
         "question": "Spot the Naked Pair in a row. Which cell is part of the pair?",
-        "hint": "Look for two cells in the same row that can only hold the same two numbers — no other candidates are possible.",
+        "hint": "Look for two cells in the same row that can only hold the same two numbers \u2014 no other candidates are possible.",
         "answerCell": 4,
         "answerValue": "",
         "explanation": "Cells R1C5 and R1C9 form a Naked Pair with candidates {7, 9}. Since both cells can only contain 7 or 9, these two values are locked to those cells in the row, eliminating 7 and 9 from all other cells in that row.",
-        "highlightCells": [4, 8],
+        "highlightCells": [
+          4,
+          8
+        ],
         "highlightColor": "yellow"
       }
     ]
@@ -99,30 +145,38 @@
     "id": "quiz-green",
     "belt": "green",
     "beltName": "Green Belt",
-    "beltEmoji": "🟢",
+    "beltEmoji": "\ud83d\udfe2",
     "beltColor": "#34A853",
     "technique": "Pointing Pair / Box-Line Reduction",
     "questions": [
       {
         "id": "green-q1",
-        "puzzle": ".1.9.36......8....9.....5.7..2.1.43....4.2....64.7.2..7.1.....5....3......56.1.2.",
+        "puzzle": "010903600000080000900000507002010430000402000064070200701000005000030000005601020",
         "question": "Find a Pointing Pair: which cells in a box force an elimination in a row or column?",
         "hint": "When a candidate in a box is restricted to a single row or column, it eliminates that candidate from the rest of the row/column outside the box.",
         "answerCell": 27,
         "answerValue": "",
-        "explanation": "A Pointing Pair occurs when a candidate within a 3×3 box is confined to a single row or column. This means the candidate must appear in one of those two cells in the box, so it can be eliminated from the rest of that row or column outside the box. Look for a digit that appears as a candidate in only two cells of a box, both in the same row or column.",
-        "highlightCells": [27, 28, 29],
+        "explanation": "A Pointing Pair occurs when a candidate within a 3\u00d73 box is confined to a single row or column. This means the candidate must appear in one of those two cells in the box, so it can be eliminated from the rest of that row or column outside the box. Look for a digit that appears as a candidate in only two cells of a box, both in the same row or column.",
+        "highlightCells": [
+          27,
+          28,
+          29
+        ],
         "highlightColor": "green"
       },
       {
         "id": "green-q2",
-        "puzzle": ".16..78.3...8......7...1.6..48...3..6.......2..9...65..6.9...2......2...9.46..51.",
+        "puzzle": "016007803000800000070001060048000300600000002009000650060900020000002000904600510",
         "question": "Where can you apply Box-Line Reduction in this puzzle?",
         "hint": "Look for a row or column where a candidate is confined to a single box, allowing elimination from other cells in that box.",
         "answerCell": 0,
         "answerValue": "",
         "explanation": "Box-Line Reduction is the reverse of a Pointing Pair. When all instances of a candidate within a row or column fall inside a single box, that candidate can be eliminated from other cells in the box that aren't in that row or column.",
-        "highlightCells": [0, 1, 2],
+        "highlightCells": [
+          0,
+          1,
+          2
+        ],
         "highlightColor": "green"
       }
     ]
@@ -131,30 +185,38 @@
     "id": "quiz-blue",
     "belt": "blue",
     "beltName": "Blue Belt",
-    "beltEmoji": "🔵",
+    "beltEmoji": "\ud83d\udd35",
     "beltColor": "#4285F4",
     "technique": "Naked Triple / Hidden Triple",
     "questions": [
       {
         "id": "blue-q1",
-        "puzzle": ".7...8.29..2.....4854.2......83742.............32617......9.6122.....4..13.6...7.",
+        "puzzle": "070008029002000004854020000008374200000000000003261700000090612200000400130600070",
         "question": "Find three cells forming a Naked Triple. Which cell is part of it?",
-        "hint": "Three cells that together contain only three candidates — they eliminate those candidates from other cells in the group.",
+        "hint": "Three cells that together contain only three candidates \u2014 they eliminate those candidates from other cells in the group.",
         "answerCell": 26,
         "answerValue": "",
         "explanation": "A Naked Triple occurs when three cells in the same row, column, or box together contain exactly three candidate values. While each cell might have 2 or 3 candidates, the union of all candidates is exactly 3 values. These values are locked to those cells and can be eliminated from other cells in the unit.",
-        "highlightCells": [24, 25, 26],
+        "highlightCells": [
+          24,
+          25,
+          26
+        ],
         "highlightColor": "blue"
       },
       {
         "id": "blue-q2",
-        "puzzle": ".........231.9.....65..31....8924...1...5...6...1367....93..57.....1.843.........",
+        "puzzle": "000000000231090000065003100008924000100050006000136700009300570000010843000000000",
         "question": "Where is the Hidden Triple in this puzzle?",
         "hint": "Three numbers that can only appear in three specific cells within a group, eliminating other candidates from those cells.",
         "answerCell": 2,
         "answerValue": "",
         "explanation": "A Hidden Triple occurs when three candidate values each appear in only three cells within a row, column, or box. Other candidates in those three cells can be eliminated, since those cells must hold exactly those three values between them.",
-        "highlightCells": [0, 1, 2],
+        "highlightCells": [
+          0,
+          1,
+          2
+        ],
         "highlightColor": "blue"
       }
     ]
@@ -163,30 +225,37 @@
     "id": "quiz-purple",
     "belt": "purple",
     "beltName": "Purple Belt",
-    "beltEmoji": "🟣",
+    "beltEmoji": "\ud83d\udfe3",
     "beltColor": "#9C27B0",
     "technique": "X-Wing / Swordfish",
     "questions": [
       {
         "id": "purple-q1",
-        "puzzle": "1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5",
+        "puzzle": "100000569402000008050009040000640801000010000208035000040500010900000402621000005",
         "question": "Spot the X-Wing pattern. Which cell is part of the X-Wing?",
         "hint": "An X-Wing occurs when a candidate appears in exactly two cells in two rows, and those cells align in the same two columns.",
         "answerCell": 1,
         "answerValue": "",
         "explanation": "An X-Wing pattern forms when a specific digit appears as a candidate in exactly two cells in each of two rows, and those cells are in the same two columns. This creates an 'X' shape that forces the digit into one diagonal pair, eliminating it from other cells in those columns.",
-        "highlightCells": [1, 5],
+        "highlightCells": [
+          1,
+          5
+        ],
         "highlightColor": "red"
       },
       {
         "id": "purple-q2",
-        "puzzle": ".51...83.4.......7...1.9.5...34..6.568..3....2..5..3..9..8.7.2.........1834....96",
+        "puzzle": "051000830400000007000109050003400605680030000200500300900807020000000001834000096",
         "question": "Find the Swordfish pattern. Which row contains part of the Swordfish?",
-        "hint": "A Swordfish is like an X-Wing with three rows and three columns — look for a candidate appearing in exactly three cells across three rows.",
+        "hint": "A Swordfish is like an X-Wing with three rows and three columns \u2014 look for a candidate appearing in exactly three cells across three rows.",
         "answerCell": 10,
         "answerValue": "",
         "explanation": "A Swordfish extends the X-Wing concept to three rows and three columns. When a candidate appears in exactly three cells in each of three rows, and those cells align in exactly three columns, the candidate can be eliminated from other cells in those columns.",
-        "highlightCells": [10, 11, 12],
+        "highlightCells": [
+          10,
+          11,
+          12
+        ],
         "highlightColor": "red"
       }
     ]
@@ -195,30 +264,35 @@
     "id": "quiz-brown",
     "belt": "brown",
     "beltName": "Brown Belt",
-    "beltEmoji": "🟤",
+    "beltEmoji": "\ud83d\udfe4",
     "beltColor": "#795548",
     "technique": "XY-Wing / XYZ-Wing",
     "questions": [
       {
         "id": "brown-q1",
-        "puzzle": ".345.....8.2.6.4..6....8.....39....4.5.....9.9....58.....3....8..1.4.6.5.....712.",
+        "puzzle": "034500000802060400600008000003900004050000090900005800000300008001040605000007120",
         "question": "Find the XY-Wing: which cell is the pivot of the XY-Wing?",
         "hint": "An XY-Wing has a pivot cell with two candidates, and two wing cells that each share one candidate with the pivot.",
         "answerCell": 0,
         "answerValue": "",
         "explanation": "An XY-Wing uses three cells: a pivot with candidates XY, and two wings with candidates XZ and YZ respectively. The shared candidate Z can be eliminated from any cell that sees both wings, because one of the wings must hold Z.",
-        "highlightCells": [0],
+        "highlightCells": [
+          0
+        ],
         "highlightColor": "yellow"
       },
       {
         "id": "brown-q2",
-        "puzzle": ".....3...647........59.72......9.......346.95.8..5...49..17....1.3.846....86.95..",
+        "puzzle": "000003000647000000005907200000090000000346095080050004900170000103084600008609500",
         "question": "Where can you spot an XY-Wing or XYZ-Wing elimination?",
         "hint": "Look for three cells with specific candidate overlaps: a pivot cell and two wing cells sharing candidates.",
         "answerCell": 18,
         "answerValue": "",
         "explanation": "The XYZ-Wing is a variant where the pivot cell has three candidates (XYZ) and two wings have two candidates each (XZ and YZ). The candidate Z common to all three cells can be eliminated from any cell that sees all three.",
-        "highlightCells": [18, 19],
+        "highlightCells": [
+          18,
+          19
+        ],
         "highlightColor": "yellow"
       }
     ]
@@ -227,30 +301,34 @@
     "id": "quiz-black",
     "belt": "black",
     "beltName": "Black Belt",
-    "beltEmoji": "⬛",
+    "beltEmoji": "\u2b1b",
     "beltColor": "#333333",
     "technique": "Unique Rectangle / Simple Coloring / W-Wing",
     "questions": [
       {
         "id": "black-q1",
-        "puzzle": ".8..9..3..3.........2.6.1.8.2.8..5..8..9.7..6..4..5.7.5.3.4.9.........1..1..5..2.",
+        "puzzle": "080090030030000000002060108020800500800907006004005070503040900000000010010050020",
         "question": "Find the Unique Rectangle pattern. Which cell is part of the deadly pattern?",
-        "hint": "A Unique Rectangle occurs when four cells form a rectangle with the same two candidates — this would create multiple solutions.",
+        "hint": "A Unique Rectangle occurs when four cells form a rectangle with the same two candidates \u2014 this would create multiple solutions.",
         "answerCell": 40,
         "answerValue": "",
         "explanation": "A Unique Rectangle exploits the fact that valid Sudoku puzzles have exactly one solution. When four cells at the corners of a rectangle share the same two candidates, one of those candidates must be eliminated to avoid creating two valid solutions.",
-        "highlightCells": [40],
+        "highlightCells": [
+          40
+        ],
         "highlightColor": "red"
       },
       {
         "id": "black-q2",
-        "puzzle": "3...547.....3.9.6..5921....7..1.24.6.2...5...93..765......2..7......3..4......2.1",
+        "puzzle": "300054700000309060059210000700102406020005000930076500000020070000003004000000201",
         "question": "Where can Simple Coloring eliminate a candidate?",
         "hint": "Color pairs of the same candidate to find a contradiction that eliminates one color.",
         "answerCell": 2,
         "answerValue": "",
         "explanation": "Simple Coloring chains pairs of a single candidate through the grid. By alternating two colors along the chain, if both colors appear in the same row, column, or box, we can eliminate all candidates of one color since that would create a contradiction.",
-        "highlightCells": [2],
+        "highlightCells": [
+          2
+        ],
         "highlightColor": "red"
       }
     ]
@@ -259,30 +337,34 @@
     "id": "quiz-master",
     "belt": "master",
     "beltName": "Master Belt",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltColor": "#FFD700",
     "technique": "Advanced Techniques",
     "questions": [
       {
         "id": "master-q1",
-        "puzzle": "8..4.9...2...7.....5.2..3...428.1.3..3.....9..8.9.321...6..7.4.....2...1...6.4..3",
+        "puzzle": "800409000200070000050200300042801030030000090080903210006007040000020001000604003",
         "question": "Which advanced technique (ALS-XZ, Death Blossom, Forcing Chains) applies here?",
         "hint": "Look for Almost Locked Sets that interact through a restricted common candidate.",
         "answerCell": 40,
         "answerValue": "",
-        "explanation": "ALS-XZ (Almost Locked Set XZ) is an advanced technique where two Almost Locked Sets — sets of N cells with N+1 candidates — share a restricted common candidate. This allows eliminating the non-restricted candidate from cells that see all instances of it in both ALS.",
-        "highlightCells": [40],
+        "explanation": "ALS-XZ (Almost Locked Set XZ) is an advanced technique where two Almost Locked Sets \u2014 sets of N cells with N+1 candidates \u2014 share a restricted common candidate. This allows eliminating the non-restricted candidate from cells that see all instances of it in both ALS.",
+        "highlightCells": [
+          40
+        ],
         "highlightColor": "red"
       },
       {
         "id": "master-q2",
-        "puzzle": ".1.....9...69..21..47.138..........53.24.....468.....27..529.4862.....3.....4....",
+        "puzzle": "010000090006900210047013800000000005302400000468000002700529048620000030000040000",
         "question": "Find the cell that can only be determined through advanced elimination techniques.",
         "hint": "Look for cells where multiple candidates remain after basic techniques are exhausted.",
         "answerCell": 0,
         "answerValue": "2",
         "explanation": "Cell R1C1 requires advanced techniques to solve. After all basic eliminations (naked/hidden singles, pairs, pointing pairs, etc.), this cell still has multiple candidates and needs techniques like Forcing Chains or Death Blossom to determine its value.",
-        "highlightCells": [0],
+        "highlightCells": [
+          0
+        ],
         "highlightColor": "red"
       }
     ]


### PR DESCRIPTION
Refs #391

## Problem
13 out of 18 quiz puzzles used `.` for empty cells while the rest of the API uses `0`. The frontend treats `0` as empty but displays literal zeros for `.` format, breaking the board for orange+ belt quizzes.

## Fix
Normalized all quiz puzzle strings in `quizzes.json` to use `0` for empty cells consistently.

- orange-q1, green-q1, green-q2, blue-q1, blue-q2, purple-q1, purple-q2, brown-q1, brown-q2, black-q1, black-q2, master-q1, master-q2: `.` → `0`

## Testing
- [x] All backend tests pass (`./gradlew test`)
- [x] All answerCells still point to empty cells (verified programmatically)