### PR TITLE
fix: map eliminator display names to specific StepTypes in step-by-step solver

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/StepType.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/StepType.kt
@@ -14,6 +14,8 @@ enum class StepType(val displayName: String, val description: String) {
     X_WING("X-Wing", "Found X-Wing pattern eliminating candidates"),
     SWORDFISH("Swordfish", "Found Swordfish pattern eliminating candidates"),
     XY_WING("XY-Wing", "Found XY-Wing pattern eliminating candidates"),
+    NAKED_SUBSET("Naked Subset", "Found naked pair/triple/quad eliminating candidates in a group"),
+    HIDDEN_SUBSET("Hidden Subset", "Found hidden pair/triple/quad values in a group"),
 
     // Actions
     CELL_FILLED("Cell Filled", "Filled a cell with its only remaining candidate"),
@@ -33,12 +35,32 @@ enum class StepType(val displayName: String, val description: String) {
         /**
          * Try to find a matching StepType for an eliminator display name.
          * Falls back to TECHNIQUE_APPLIED if no match.
+         *
+         * Matching strategy:
+         * 1. Exact match on displayName or enum name (case-insensitive)
+         * 2. Normalized match (strip hyphens, spaces, parentheses)
+         * 3. Explicit aliases for generic eliminators
          */
         fun fromTechniqueName(name: String): StepType {
-            return entries.firstOrNull {
+            // Direct match on display name or enum name
+            entries.firstOrNull {
                 it.displayName.equals(name, ignoreCase = true) ||
                 it.name.replace("_", " ").equals(name, ignoreCase = true)
-            } ?: TECHNIQUE_APPLIED
+            }?.let { return it }
+
+            // Normalized match: strip hyphens, spaces, parentheses for comparison
+            // e.g. "XWing" matches "X-Wing", "XYWing" matches "XY-Wing"
+            val normalized = name.lowercase().replace("[-\\s()]", "")
+            entries.firstOrNull {
+                it.displayName.lowercase().replace("[-\\s()]", "") == normalized ||
+                it.name.lowercase().replace("_", "") == normalized
+            }?.let { return it }
+
+            // Explicit aliases for generic eliminator names
+            return when {
+                name.startsWith("Exclusion", ignoreCase = true) -> SIMPLE_ELIMINATION
+                else -> TECHNIQUE_APPLIED
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

The step-by-step solver (`/api/v1/step-by-step`) reports `technique: "Technique Applied"` for most elimination techniques instead of the specific technique name (e.g. "X-Wing", "Naked Subset", "Swordfish").

This makes the step-by-step output less useful — students and the UI cannot distinguish which technique was actually applied at each step.

## Root Causes

1. **Hyphen mismatch**: `XWingCandidateEliminator` reports `"XWing"` but `StepType.X_WING` has displayName `"X-Wing"` — exact match fails
2. **No generic StepType**: `GroupCandidateEliminator` reports `"Naked Subset"` but only `NAKED_PAIR`/`NAKED_TRIPLE` StepTypes existed (not generic)
3. **Same for Hidden Subset**: `HiddenSubsetCandidateEliminator` reports `"Hidden Subset"` with no matching StepType
4. **Parenthesized names**: `ExclusionCandidateEliminator` reports `"Exclusion(9)"` — no match

## Changes

- Add `NAKED_SUBSET` and `HIDDEN_SUBSET` StepType entries for generic subset eliminators
- Add normalized matching (strip hyphens, spaces, parentheses) as second pass:
  - `"XWing"` → matches `X_WING ("X-Wing")`
  - `"XYWing"` → matches `XY_WING ("XY-Wing")`
  - `"SimpleColoring"` → matches if added later
- Add explicit alias: `"Exclusion*"` → `SIMPLE_ELIMINATION`
- Backward-compatible: exact matching remains first pass

## Testing

- All existing tests pass (`./gradlew test`)
- Verified locally: step-by-step endpoint now shows specific technique names instead of "Technique Applied"

Refs #396