### PR TITLE
fix: read version info from classpath version.properties at runtime

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/DeployInfoRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/DeployInfoRoutes.kt
@@ -6,6 +6,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import java.io.File
+import java.util.Properties
 
 /**
  * Lightweight deploy-info endpoint for monitoring and deploy verification.
@@ -19,11 +20,36 @@ data class DeployInfoResponse(
 )
 
 /**
- * Read the deployed git commit hash from a file.
- * Path is configurable via DEPLOY_COMMIT_FILE env var (default: /opt/sudoku/.deploy-commit).
- * Returns null if the file is missing or unreadable (graceful degradation).
+ * Build version info loaded from classpath version.properties (injected at build time by Gradle).
+ * Falls back to null if properties are not available (e.g. during development without build).
+ */
+private val buildVersionInfo: Pair<String?, String?> by lazy {
+    try {
+        val props = Properties()
+        val stream = Thread.currentThread().contextClassLoader
+            .getResourceAsStream("version.properties")
+        if (stream != null) {
+            props.load(stream)
+            val commit = props.getProperty("gitCommit")?.takeIf { it != "unknown" && it.isNotEmpty() }
+            val time = props.getProperty("buildTime")?.takeIf { it.isNotEmpty() }
+            Pair(commit, time)
+        } else {
+            Pair(null, null)
+        }
+    } catch (_: Exception) {
+        Pair(null, null)
+    }
+}
+
+/**
+ * Read the git commit hash.
+ * Priority: classpath version.properties > deploy commit file.
  */
 internal fun readGitCommit(): String? {
+    // Try classpath first (build-time injected)
+    buildVersionInfo.first?.let { return it }
+
+    // Fallback: deploy commit file
     return try {
         val commitFile = File(System.getenv("DEPLOY_COMMIT_FILE") ?: "/opt/sudoku/.deploy-commit")
         if (commitFile.isFile) commitFile.readText().trim().takeIf { it.isNotEmpty() } else null
@@ -33,10 +59,14 @@ internal fun readGitCommit(): String? {
 }
 
 /**
- * Read build timestamp from a file placed by the build pipeline.
- * Returns null if the file is missing or unreadable.
+ * Read build timestamp.
+ * Priority: classpath version.properties > build timestamp file.
  */
 internal fun readBuildTimestamp(): String? {
+    // Try classpath first (build-time injected)
+    buildVersionInfo.second?.let { return it }
+
+    // Fallback: build timestamp file
     return try {
         val timestampFile = File(System.getenv("BUILD_TIMESTAMP_FILE") ?: "/opt/sudoku/.build-timestamp")
         if (timestampFile.isFile) timestampFile.readText().trim().takeIf { it.isNotEmpty() } else null

--- a/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
@@ -5,7 +5,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
-import java.io.File
 import java.lang.management.ManagementFactory
 import java.lang.management.MemoryMXBean
 import java.lang.management.RuntimeMXBean
@@ -118,13 +117,8 @@ fun Route.healthRoutes() {
             else -> "OK"
         }
 
-        // Read deployed commit hash (file path from env, default /opt/sudoku/.deploy-commit)
-        val gitCommit = try {
-            val commitFile = File(System.getenv("DEPLOY_COMMIT_FILE") ?: "/opt/sudoku/.deploy-commit")
-            if (commitFile.isFile) commitFile.readText().trim().takeIf { it.isNotEmpty() } else null
-        } catch (_: Exception) {
-            null
-        }
+        // Read git commit hash — classpath version.properties first, then deploy file
+        val gitCommit = readGitCommit()
 
         call.respond(
             HttpStatusCode.OK,


### PR DESCRIPTION
## Problem

The `/api/v1/deploy-info` and `/api/v1/health` endpoints read git commit hash and build timestamp from filesystem files (`/opt/sudoku/.deploy-commit`, `/opt/sudoku/.build-timestamp`) placed by the deployer. This means version info is **unavailable** in Docker, local dev, or any non-deployed environment.

Currently `buildTimestamp` is always `null` because the deployer never creates that file.

## Solution

The Gradle build already generates `version.properties` with `gitCommit` and `buildTime` (injected at build time). This PR makes the runtime code actually **read** from the classpath.

### Changes
- Add classpath `version.properties` loader (lazy-loaded, cached) in `DeployInfoRoutes.kt`
- `readGitCommit()`: tries classpath first, falls back to deploy file
- `readBuildTimestamp()`: tries classpath first, falls back to file  
- `HealthRoutes`: delegates to shared `readGitCommit()` instead of duplicate file-reading code

### Before
```json
GET /api/v1/deploy-info → {"version":"1.0.0","gitCommit":"2439d31","buildTimestamp":null}
```

### After (works without deploy files)
```json
GET /api/v1/deploy-info → {"version":"1.0.0","gitCommit":"2439d31","buildTimestamp":"1778739354382"}
```

## Testing
- All tests pass (`./gradlew test`)
- Verified locally: both endpoints return gitCommit and buildTimestamp from classpath
- Backward compatible: still falls back to deploy files if classpath properties unavailable

Refs #401