### PR TITLE
fix: correct red belt quiz Q2 answerValue (5 → 6)

### DIFF
--- a/web/src/main/resources/tutorials/quizzes.json
+++ b/web/src/main/resources/tutorials/quizzes.json
@@ -446,7 +446,7 @@
         "question": "Where can you apply a W-Wing elimination to narrow down candidates?",
         "hint": "Look for two cells with the same two candidates that are connected through a strong link in a column or box.",
         "answerCell": 36,
-        "answerValue": "5",
+        "answerValue": "6",
         "explanation": "The W-Wing technique identifies two bivalue cells with the same candidates connected by a strong link on one candidate. Any cell seeing both wings cannot contain the other candidate. This elimination often reveals hidden singles or further techniques.",
         "highlightCells": [
           36,


### PR DESCRIPTION
## Problem
Red belt quiz Q2 (`red-q2`) has `answerValue: "5"` for `answerCell: 36` (R5C1), but the solver solution shows value `6` at that cell. Students clicking the correct cell get told the answer is wrong.

## Fix
One-line change: `answerValue` from `"5"` to `"6"` in `quizzes.json`.

## Verification
```
Solution: 853672491926143857147958632285714963631529748794836215418265379372491586569387124
Cell 36 (R5C1) = 6 ✓
```

All tests pass (`./gradlew test`).

Fixes #413