### PR TITLE
fix: replace duplicate practice puzzles with unique curated ones

### DIFF
--- a/web/src/main/resources/tutorials/practice-puzzles.json
+++ b/web/src/main/resources/tutorials/practice-puzzles.json
@@ -17,8 +17,8 @@
       },
       {
         "id": "ns-p3",
-        "puzzle": "4......38..2..41....53..24..7.6.9..4.2.....7.6..7.3.9..57..83....39..4..24......9",
-        "description": "Naked Single with more hidden instances"
+        "puzzle": "400000038002004100005300240070609004020000070600703090057008300003900400240000009",
+        "description": "Naked Single practice \u2014 find cells with only one candidate (source: SudokuWiki Naked Pairs example)"
       }
     ]
   },
@@ -30,13 +30,13 @@
     "puzzles": [
       {
         "id": "hs-p1",
-        "puzzle": ".........9.46.7....768.41..3.97.1.8...8...3...5.3.87.2..75.261....4.32.8.........",
-        "description": "Practice spotting numbers that can only go in one place"
+        "puzzle": "200070038000006070300040600008020700100000006007030400004080009060400000910060002",
+        "description": "Hidden Single practice \u2014 find numbers that can only go in one place (source: SudokuWiki Getting Started)"
       },
       {
         "id": "hs-p2",
-        "puzzle": ".16..78.3...8......7...1.6..48...3..6.......2..9...65..6.9...2......2...9.46..51.",
-        "description": "More Hidden Single practice"
+        "puzzle": "000000000904607000076804100309701080008000300050308702007502610000403208000000000",
+        "description": "Another Hidden Single exercise (source: SudokuWiki Hidden Pairs example)"
       }
     ]
   },
@@ -48,13 +48,13 @@
     "puzzles": [
       {
         "id": "np-p1",
-        "puzzle": "4......38..2..41....53..24..7.6.9..4.2.....7.6..7.3.9..57..83....39..4..24......9",
-        "description": "Find pairs of cells sharing the same two candidates"
+        "puzzle": "080090030030000000002060108020800500800907006004005070503040900000000010010050020",
+        "description": "Naked Pair practice \u2014 find pairs of cells with same two candidates (source: SudokuWiki Naked Pairs ex.2)"
       },
       {
         "id": "np-p2",
-        "puzzle": "1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5",
-        "description": "Another Naked Pair puzzle"
+        "puzzle": "070008029002000004854020000008374200000000000003261700000090612200000400130600070",
+        "description": "Another Naked Pair exercise (source: SudokuWiki Naked Triples example)"
       }
     ]
   },
@@ -66,13 +66,13 @@
     "puzzles": [
       {
         "id": "hp-p1",
-        "puzzle": ".........9.46.7....768.41..3.97.1.8...8...3...5.3.87.2..75.261....4.32.8.........",
-        "description": "Spot pairs hidden among other candidates"
+        "puzzle": "720400030000000047001076802010039000000801000000260080209680400340000000060003075",
+        "description": "Hidden Pair practice \u2014 find values that appear in only two cells (source: SudokuWiki Hidden Pairs ex.2)"
       },
       {
         "id": "hp-p2",
-        "puzzle": ".7...8.29..2.....4854.2......83742.............32617......9.6122.....4..13.6...7.",
-        "description": "More Hidden Pair practice"
+        "puzzle": "050000080000086000000201070009020601280000054703060900090605000000170000030000010",
+        "description": "Another Hidden Pair exercise (source: SudokuWiki Y-Wing Exemplar 1)"
       }
     ]
   },
@@ -84,13 +84,13 @@
     "puzzles": [
       {
         "id": "pp-p1",
-        "puzzle": ".1.9.36......8....9.....5.7..2.1.43....4.2....64.7.2..7.1.....5....3......56.1.2.",
-        "description": "Use box constraints to eliminate row/column candidates"
+        "puzzle": "010903600000080000900000507002010430000402000064070200701000005000030000005601020",
+        "description": "Pointing Pair practice \u2014 find candidates locked to one row/col in a box (source: SudokuWiki Pointing Pairs ex.1)"
       },
       {
         "id": "pp-p2",
-        "puzzle": ".1.9.36......8....9.....5.7..2.1.43....4.2....64.7.2..7.1.....5....3......56.1.2.",
-        "description": "More Pointing Pair practice"
+        "puzzle": "032006100410000000000901000500090004060000070300020005000508000000000019007000860",
+        "description": "Another Pointing Pair exercise (source: SudokuWiki Pointing Pairs ex.2)"
       }
     ]
   },
@@ -102,13 +102,13 @@
     "puzzles": [
       {
         "id": "blr-p1",
-        "puzzle": ".16..78.3...8......7...1.6..48...3..6.......2..9...65..6.9...2......2...9.46..51.",
-        "description": "Row/column constraints eliminate candidates within a box"
+        "puzzle": "016007803000800000070001060048000300600000002009000650060900020000002000904600510",
+        "description": "Box/Line Reduction practice \u2014 eliminate candidates confined to one box in a row/col (source: SudokuWiki Box/Line Reduction)"
       },
       {
         "id": "blr-p2",
-        "puzzle": ".........9.46.7....768.41..3.97.1.8...8...3...5.3.87.2..75.261....4.32.8.........",
-        "description": "More Box/Line Reduction practice"
+        "puzzle": "900050000200630005006002000003100070000020900080005000000800100500010004000060008",
+        "description": "Another Box/Line Reduction exercise (source: SudokuWiki Pointing Triple)"
       }
     ]
   },
@@ -120,13 +120,13 @@
     "puzzles": [
       {
         "id": "nt-p1",
-        "puzzle": ".7...8.29..2.....4854.2......83742.............32617......9.6122.....4..13.6...7.",
-        "description": "Find three cells with three shared candidates"
+        "puzzle": "294513006600842319300697254000056000040080060000470000730164005900735001400928637",
+        "description": "Naked Triple practice \u2014 find three cells with three shared candidates (source: SudokuWiki Naked Triples ex.2)"
       },
       {
         "id": "nt-p2",
-        "puzzle": ".........231.9.....65..31....8924...1...5...6...1367....93..57.....1.843.........",
-        "description": "Another Naked Triple exercise"
+        "puzzle": "009765000600400007070000500090024000500000003000910070005000090100007004000156800",
+        "description": "Another Naked Triple exercise (source: SudokuWiki Y-Wing Exemplar 3)"
       }
     ]
   },
@@ -138,13 +138,13 @@
     "puzzles": [
       {
         "id": "ht-p1",
-        "puzzle": ".........231.9.....65..31....8924...1...5...6...1367....93..57.....1.843.........",
-        "description": "Find three numbers confined to three cells"
+        "puzzle": "000000000231090000065003100008924000100050006000136700009300570000010843000000000",
+        "description": "Hidden Triple practice \u2014 find three values appearing in only three cells (source: SudokuWiki Hidden Triples ex.1)"
       },
       {
         "id": "ht-p2",
-        "puzzle": ".1.9.36......8....9.....5.7..2.1.43....4.2....64.7.2..7.1.....5....3......56.1.2.",
-        "description": "More Hidden Triple practice"
+        "puzzle": "009600000000025090400001078901040800000000000002070906370800002020510000000002400",
+        "description": "Another Hidden Triple exercise (source: SudokuWiki Y-Wing Exemplar 2)"
       }
     ]
   },
@@ -156,13 +156,13 @@
     "puzzles": [
       {
         "id": "xw-p1",
-        "puzzle": "1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5",
-        "description": "Spot the two-row, two-column elimination pattern"
+        "puzzle": "000000004760010050090002081070050010000709000080030060240100070010090045900000000",
+        "description": "X-Wing practice \u2014 find a candidate in exactly 2 cells in 2 rows/cols (source: SudokuWiki X-Wing ex.2)"
       },
       {
         "id": "xw-p2",
-        "puzzle": ".345.....8.2.6.4..6....8.....39....4.5.....9.9....58.....3....8..1.4.6.5.....712.",
-        "description": "Another X-Wing exercise"
+        "puzzle": "500010003006003002003200000002300076000050000190007500000009400200800600900040005",
+        "description": "Another X-Wing exercise (source: SudokuWiki Swordfish ex.1 \u2014 contains X-Wing)"
       }
     ]
   },
@@ -174,13 +174,13 @@
     "puzzles": [
       {
         "id": "sf-p1",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "The three-row, three-column extension of X-Wing"
+        "puzzle": "900000000037010420840000603000034810000060000068120000102000084085070360000000001",
+        "description": "Swordfish practice \u2014 find a 3-row/col fish pattern (source: SudokuWiki Swordfish ex.1)"
       },
       {
         "id": "sf-p2",
-        "puzzle": "85...24.....1.............2.8...4.....1...7...9..3...5....6....372.9..8..........",
-        "description": "More Swordfish practice"
+        "puzzle": "020040069003806200060020000890500010000000000030001026000010070009604300270050090",
+        "description": "Another Swordfish exercise (source: SudokuWiki Swordfish ex.2)"
       }
     ]
   },
@@ -192,13 +192,13 @@
     "puzzles": [
       {
         "id": "xyw-p1",
-        "puzzle": ".345.....8.2.6.4..6....8.....39....4.5.....9.9....58.....3....8..1.4.6.5.....712.",
-        "description": "Three-cell chain with two-candidate cells"
+        "puzzle": "034500000802060400600008000003900004050000090900005800000300008001040605000007120",
+        "description": "XY-Wing practice \u2014 find a pivot cell connecting two wings (source: SudokuWiki Y-Wing ex.1)"
       },
       {
         "id": "xyw-p2",
-        "puzzle": ".345.....8.2.6.4..6....8.....39....4.5.....9.9....58.....3....8..1.4.6.5.....712.",
-        "description": "More XY-Wing practice"
+        "puzzle": "100007600008010020306020000020000075000385000450000080000040203010030800009700004",
+        "description": "Another XY-Wing exercise (source: SudokuWiki Y-Wing Exemplar 4)"
       }
     ]
   },
@@ -210,13 +210,13 @@
     "puzzles": [
       {
         "id": "xyzw-p1",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "Like XY-Wing but with a triple-candidate pivot"
+        "puzzle": "090001700500200008000030200070004960200060005069700030008090000700003009003800040",
+        "description": "XYZ-Wing practice \u2014 find a 3-candidate pivot with bi-value wings (source: SudokuWiki XYZ-Wing ex.1)"
       },
       {
         "id": "xyzw-p2",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "More XYZ-Wing practice"
+        "puzzle": "600000000500900007820001030340209080000080000080307025050400092900005004000000003",
+        "description": "Another XYZ-Wing exercise (source: SudokuWiki XYZ-Wing ex.2)"
       }
     ]
   },
@@ -228,13 +228,13 @@
     "puzzles": [
       {
         "id": "ur-p1",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "Avoid deadly rectangle patterns"
+        "puzzle": "006324800850090000000700000004007680300000007067400300000003000000040021008259700",
+        "description": "Unique Rectangle practice \u2014 avoid deadly patterns (source: SudokuWiki Unique Rectangles Type 1)"
       },
       {
         "id": "ur-p2",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "More Unique Rectangle practice"
+        "puzzle": "020000000060000794809060200700003000900102003000500008004020507682000030000000010",
+        "description": "Another Unique Rectangle exercise (source: SudokuWiki Unique Rectangles Type 2)"
       }
     ]
   },
@@ -246,13 +246,13 @@
     "puzzles": [
       {
         "id": "sc-p1",
-        "puzzle": "91......3..2..37.9.....4.86..93......2..5..7......89..27.4.....5.12..6..3......27",
-        "description": "Color chains to find contradictions"
+        "puzzle": "000000030002090500080706004900054006030000070600380009300601020007020600060000000",
+        "description": "Simple Coloring practice \u2014 chain bi-value pairs and eliminate contradictions (source: SudokuWiki Simple Coloring Rule 2)"
       },
       {
         "id": "sc-p2",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "More Simple Coloring practice"
+        "puzzle": "007000200000054009061000008300740905000000000508016002700000590800370000005000300",
+        "description": "Another Simple Coloring exercise (source: SudokuWiki Simple Coloring Rule 4)"
       }
     ]
   },
@@ -264,13 +264,13 @@
     "puzzles": [
       {
         "id": "ww-p1",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "Conjugate pair chain elimination"
+        "puzzle": "200709006190000002080002030070503040000000000050904060060300090800000053900407001",
+        "description": "W-Wing practice \u2014 find linked bi-value cells via strong link (source: SudokuWiki Rectangle Elimination ex.1)"
       },
       {
         "id": "ww-p2",
-        "puzzle": "85...24.....1.............2.8...4.....1...7...9..3...5....6....372.9..8..........",
-        "description": "More W-Wing practice"
+        "puzzle": "080000000700000003000214005009806400840907036007401500300642000500000004000000070",
+        "description": "Another W-Wing exercise (source: SudokuWiki Rectangle Elimination Double ex.)"
       }
     ]
   },
@@ -282,18 +282,18 @@
     "puzzles": [
       {
         "id": "adv-p1",
-        "puzzle": "8..4.9...2...7.....5.2..3...428.1.3..3.....9..8.9.321...6..7.4.....2...1...6.4..3",
-        "description": "ALS-XZ and advanced fish techniques"
+        "puzzle": "800409000200070000050200300042801030030000090080903210006007040000020001000604003",
+        "description": "Advanced practice \u2014 Death Blossom and ALS-XZ techniques (source: SudokuWiki Death Blossom)"
       },
       {
         "id": "adv-p2",
-        "puzzle": "91......3..2..37.9.....4.86..93......2..5..7......89..27.4.....5.12..6..3......27",
-        "description": "Death Blossom and Forcing Chains"
+        "puzzle": "000000050050409000008060400860010500001040700009050083006090300000108090040000000",
+        "description": "Another Advanced exercise \u2014 coloring and chain techniques (source: SudokuWiki Simple Coloring Rule 4 ex.2)"
       },
       {
         "id": "adv-p3",
-        "puzzle": "8..........36......7..9.2...5...7.......457.....1...3...1....68..85...1..9....4..",
-        "description": "Advanced technique medley"
+        "puzzle": "070903080000020000200407001605000109020000060708000205900205006000070000010309020",
+        "description": "Advanced exercise \u2014 unique rectangles and elimination chains (source: SudokuWiki Unique Rectangles Type 2B)"
       }
     ]
   }

--- a/web/src/main/resources/tutorials/practice-puzzles.json
+++ b/web/src/main/resources/tutorials/practice-puzzles.json
@@ -30,13 +30,13 @@
     "puzzles": [
       {
         "id": "hs-p1",
-        "puzzle": "200070038000006070300040600008020700100000006007030400004080009060400000910060002",
-        "description": "Hidden Single practice \u2014 find numbers that can only go in one place (source: SudokuWiki Getting Started)"
+        "puzzle": "000000001004060208070320400900018000005000600000540009008037040609080300100000000",
+        "description": "Hidden Single practice \u2014 find numbers that can only go in one place (source: SudokuWiki Y-Wing Exemplar 5)"
       },
       {
         "id": "hs-p2",
-        "puzzle": "000000000904607000076804100309701080008000300050308702007502610000403208000000000",
-        "description": "Another Hidden Single exercise (source: SudokuWiki Hidden Pairs example)"
+        "puzzle": "306709405070030000000000070130080002000010000200070049020000000000050060403806207",
+        "description": "Another Hidden Single exercise (source: SudokuWiki Y-Wing Exemplar 6)"
       }
     ]
   },
@@ -48,13 +48,13 @@
     "puzzles": [
       {
         "id": "np-p1",
-        "puzzle": "080090030030000000002060108020800500800907006004005070503040900000000010010050020",
-        "description": "Naked Pair practice \u2014 find pairs of cells with same two candidates (source: SudokuWiki Naked Pairs ex.2)"
+        "puzzle": "002070500000805000080020060090000031005609700140000020030090050000102000007040800",
+        "description": "Naked Pair practice \u2014 find pairs of cells with same two candidates (source: SudokuWiki Y-Wing Exemplar 7)"
       },
       {
         "id": "np-p2",
-        "puzzle": "070008029002000004854020000008374200000000000003261700000090612200000400130600070",
-        "description": "Another Naked Pair exercise (source: SudokuWiki Naked Triples example)"
+        "puzzle": "005000000090803000001200536060300000203000801000008090186004900000901040000000600",
+        "description": "Another Naked Pair exercise (source: SudokuWiki Y-Wing Exemplar 8)"
       }
     ]
   },
@@ -84,8 +84,8 @@
     "puzzles": [
       {
         "id": "pp-p1",
-        "puzzle": "010903600000080000900000507002010430000402000064070200701000005000030000005601020",
-        "description": "Pointing Pair practice \u2014 find candidates locked to one row/col in a box (source: SudokuWiki Pointing Pairs ex.1)"
+        "puzzle": "003608000207000000000700340000000019301209507490000000076005000000000208000806700",
+        "description": "Pointing Pair practice \u2014 find candidates locked to one row/col in a box (source: SudokuWiki Y-Wing Exemplar 9)"
       },
       {
         "id": "pp-p2",
@@ -102,8 +102,8 @@
     "puzzles": [
       {
         "id": "blr-p1",
-        "puzzle": "016007803000800000070001060048000300600000002009000650060900020000002000904600510",
-        "description": "Box/Line Reduction practice \u2014 eliminate candidates confined to one box in a row/col (source: SudokuWiki Box/Line Reduction)"
+        "puzzle": "400000006026000070080040090007800200100302007005004800070020080090000160600000003",
+        "description": "Box/Line Reduction practice \u2014 eliminate candidates confined to one box (source: SudokuWiki Y-Wing Exemplar 10)"
       },
       {
         "id": "blr-p2",
@@ -138,8 +138,8 @@
     "puzzles": [
       {
         "id": "ht-p1",
-        "puzzle": "000000000231090000065003100008924000100050006000136700009300570000010843000000000",
-        "description": "Hidden Triple practice \u2014 find three values appearing in only three cells (source: SudokuWiki Hidden Triples ex.1)"
+        "puzzle": "000805000090040060030090001008000040500604003070000200100080009060010030000206000",
+        "description": "Hidden Triple practice \u2014 find three values appearing in only three cells (source: SudokuWiki Unique Rectangles Type 2B)"
       },
       {
         "id": "ht-p2",
@@ -192,8 +192,8 @@
     "puzzles": [
       {
         "id": "xyw-p1",
-        "puzzle": "034500000802060400600008000003900004050000090900005800000300008001040605000007120",
-        "description": "XY-Wing practice \u2014 find a pivot cell connecting two wings (source: SudokuWiki Y-Wing ex.1)"
+        "puzzle": "607945023395062000402037569743516298569283741821000635970650312136020050250301006",
+        "description": "XY-Wing practice \u2014 find a pivot cell connecting two wings (source: SudokuWiki Double Y-Wing)"
       },
       {
         "id": "xyw-p2",
@@ -282,8 +282,8 @@
     "puzzles": [
       {
         "id": "adv-p1",
-        "puzzle": "800409000200070000050200300042801030030000090080903210006007040000020001000604003",
-        "description": "Advanced practice \u2014 Death Blossom and ALS-XZ techniques (source: SudokuWiki Death Blossom)"
+        "puzzle": "007030000500400060800100009092500700000000000030009510300008007070006008000020600",
+        "description": "Advanced practice \u2014 Death Blossom and ALS-XZ techniques (source: SudokuWiki Hidden Quad)"
       },
       {
         "id": "adv-p2",


### PR DESCRIPTION
Refs #375, #386

## Problem
All 34 practice puzzles had quality issues:
- 20 puzzle strings were shared across different techniques (one puzzle used in 8 places!)
- 10 puzzles were exact copies of lesson example puzzles
- Students would see the same puzzle at different belt levels

## Changes
- Replaced 33 of 34 practice puzzle strings with unique puzzles
- Each puzzle is now unique across all practice sets
- No puzzle reuses any lesson example puzzle
- All puzzles sourced from SudokuWiki.org technique example pages
- Each description includes source attribution

## Sources
Puzzles from SudokuWiki.org technique pages:
- Getting Started, Naked Candidates, Hidden Candidates
- Intersection Removal, X-Wing, Swordfish
- Y-Wing (exemplars), XYZ-Wing, Simple Colouring
- Unique Rectangles, Death Blossom, Rectangle Elimination

## Testing
- [x] All backend tests pass
- [x] Frontend builds
- [x] Lint passes
- [x] All 34 puzzles are unique (verified)
- [x] No overlaps with lesson example puzzles