### PR TITLE
fix: respect targetTechnique + report specific subset names (Refs #462 #463 #464 #465)

### DIFF
--- a/kotlin/src/main/java/will/sudoku/solver/CandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/CandidateEliminator.kt
@@ -8,5 +8,13 @@ interface CandidateEliminator {
      */
     val displayName: String get() = javaClass.simpleName.removeSuffix("CandidateEliminator")
 
+    /**
+     * Specific technique name from the last elimination run.
+     * Override for eliminators that report different technique names based on context
+     * (e.g., Naked Pair vs Naked Triple vs Naked Subset).
+     * Falls back to displayName by default.
+     */
+    val lastTechniqueName: String get() = displayName
+
     fun eliminate(board: Board): Boolean
 }

--- a/kotlin/src/main/java/will/sudoku/solver/GroupCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/GroupCandidateEliminator.kt
@@ -2,6 +2,10 @@ package will.sudoku.solver
 
 class GroupCandidateEliminator : CandidateEliminator {
     override val displayName = "Naked Subset"
+
+    private var _lastTechniqueName: String = displayName
+    override val lastTechniqueName: String get() = _lastTechniqueName
+
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false
         var stable: Boolean
@@ -19,6 +23,13 @@ class GroupCandidateEliminator : CandidateEliminator {
                     .keys
 
                 for (candidatePattern in candidatePatterns) {
+                    val size = candidatePattern.countOneBits()
+                    _lastTechniqueName = when (size) {
+                        2 -> "Naked Pair"
+                        3 -> "Naked Triple"
+                        else -> "Naked Subset"
+                    }
+
                     // and then exclude that pattern from other cells in the same group
                     val updated = coordGroup.coords
                         .filterNot { board.candidatePattern(it) == candidatePattern }

--- a/kotlin/src/main/java/will/sudoku/solver/HiddenSubsetCandidateEliminator.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/HiddenSubsetCandidateEliminator.kt
@@ -26,6 +26,9 @@ package will.sudoku.solver
 class HiddenSubsetCandidateEliminator : CandidateEliminator {
     override val displayName = "Hidden Subset"
 
+    private var _lastTechniqueName: String = displayName
+    override val lastTechniqueName: String get() = _lastTechniqueName
+
     override fun eliminate(board: Board): Boolean {
         var anyUpdate = false
         var stable: Boolean
@@ -93,6 +96,11 @@ class HiddenSubsetCandidateEliminator : CandidateEliminator {
         candidateToCells: Map<Int, List<Coord>>,
         subsetSize: Int
     ): Boolean {
+        _lastTechniqueName = when (subsetSize) {
+            2 -> "Hidden Pair"
+            3 -> "Hidden Triple"
+            else -> "Hidden Subset"
+        }
         // Get all candidates that appear in <= subsetSize cells
         val eligibleCandidates = candidateToCells.filterValues { it.size <= subsetSize }
 

--- a/kotlin/src/main/java/will/sudoku/solver/Solver.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/Solver.kt
@@ -156,8 +156,8 @@ class Solver(private val config: SolverConfig = SolverConfig()) {
 
                     val totalEliminated = eliminations.sumOf { it.eliminatedValues.size }
                     if (totalEliminated > 0) {
-                        listener.onEliminatorApplied(eliminator.displayName, totalEliminated)
-                        listener.onCandidatesEliminated(eliminator.displayName, eliminations)
+                        listener.onEliminatorApplied(eliminator.lastTechniqueName, totalEliminated)
+                        listener.onCandidatesEliminated(eliminator.lastTechniqueName, eliminations)
                     }
                     anyProgress = true
                 }

--- a/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
+++ b/kotlin/src/main/java/will/sudoku/solver/TeachingHint.kt
@@ -46,7 +46,10 @@ class TeachingHintProvider {
 
     fun getHint(board: Board, targetTechnique: HintGenerator.Technique? = null): TeachingHint {
         // Try Naked Single (easiest) — local check for richer teaching points
-        findNakedSingle(board)?.let { return it }
+        // Skip when a specific technique is requested so it doesn't short-circuit
+        if (targetTechnique == null) {
+            findNakedSingle(board)?.let { return it }
+        }
 
         // Delegate to HintGenerator for all other techniques.
         // For tutorials that need a specific advanced technique, pass targetTechnique


### PR DESCRIPTION
Fixes tutorial hints and step-by-step technique naming.

## #462 — TeachingHintProvider targetTechnique fix
- `getHint()` now skips Naked Single fast-path when `targetTechnique` is set
- Tutorial hints for advanced techniques no longer short-circuit to Naked Single

## #464 — Specific subset technique names
- Added `lastTechniqueName` to `CandidateEliminator` interface (defaults to `displayName`)
- `GroupCandidateEliminator`: reports "Naked Pair" (size 2), "Naked Triple" (size 3), "Naked Subset" (4+)
- `HiddenSubsetCandidateEliminator`: reports "Hidden Pair", "Hidden Triple", "Hidden Subset"
- `Solver` uses `lastTechniqueName` for step recording
- `StepType.fromTechniqueName()` already handles specific names (NAKED_PAIR, NAKED_TRIPLE, etc.)

## Verification
- ✅ All Kotlin tests pass
- ✅ Web module compiles clean