### PR TITLE
test: Validate route integration tests (Refs #479)

### DIFF
--- a/web/src/test/kotlin/will/sudoku/web/KtorTestHelper.kt
+++ b/web/src/test/kotlin/will/sudoku/web/KtorTestHelper.kt
@@ -3,6 +3,7 @@ package will.sudoku.web
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.testing.*
 import kotlinx.serialization.json.Json
 
@@ -10,113 +11,103 @@ import kotlinx.serialization.json.Json
  * Shared test infrastructure for Ktor integration tests.
  *
  * Provides:
- * - Application setup via [testApp] (configures all routes)
+ * - Application setup via [ktorTest] (configures all routes)
  * - JSON parsing utilities
  * - Common request builders for solve, validate, step-by-step, tutorials
  *
  * Usage:
  * ```kotlin
  * @Test
- * fun `my test`() = testApp {
+ * fun `my test`() = ktorTest {
  *     val response = solvePost("000000000...")
  *     assertEquals(HttpStatusCode.OK, response.status)
  * }
  * ```
  */
-object KtorTestHelper {
 
-    /**
-     * Lenient JSON parser for reading response bodies in tests.
-     */
-    val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-    }
+/**
+ * Lenient JSON parser for reading response bodies in tests.
+ */
+val testJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
 
-    // ── Puzzle Constants ─────────────────────────────────────
+// ── Puzzle Constants ─────────────────────────────────────
 
-    /**
-     * A simple, valid puzzle string for quick tests.
-     * Known solution exists.
-     */
-    const val SAMPLE_PUZZLE = "530070000600195000098000060800060003400803001700020006060000280000419005000080079"
+/**
+ * A simple, valid puzzle string for quick tests.
+ * Known solution exists.
+ */
+const val SAMPLE_PUZZLE = "530070000600195000098000060800060003400803001700020006060000280000419005000080079"
 
-    /**
-     * An invalid puzzle string (duplicate 5 in first row).
-     */
-    const val INVALID_PUZZLE = "550000000000000000000000000000000000000000000000000000000000000000000000000000000"
+/**
+ * An invalid puzzle string (duplicate 5 in first row).
+ */
+const val INVALID_PUZZLE = "550000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
-    /**
-     * An empty puzzle (all zeros) — valid but under-constrained.
-     */
-    const val EMPTY_PUZZLE = "000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+/**
+ * An empty puzzle (all zeros) — valid but under-constrained.
+ */
+const val EMPTY_PUZZLE = "000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
-    // ── Request Builders ─────────────────────────────────────
+// ── Request Builders (extension functions on ApplicationTestBuilder) ─
 
-    /**
-     * POST a puzzle to /api/v1/solve and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.solvePost(puzzle: String): HttpResponse {
-        return client.post("/api/v1/solve") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"puzzle":"$puzzle"}""")
-        }
-    }
-
-    /**
-     * POST a puzzle to /api/v1/validate and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.validatePost(puzzle: String): HttpResponse {
-        return client.post("/api/v1/validate") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"puzzle":"$puzzle"}""")
-        }
-    }
-
-    /**
-     * POST a puzzle to /api/v1/step-by-step and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.stepByStepPost(puzzle: String): HttpResponse {
-        return client.post("/api/v1/step-by-step") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"puzzle":"$puzzle"}""")
-        }
-    }
-
-    /**
-     * POST a puzzle to /api/v1/hint and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.hintPost(puzzle: String): HttpResponse {
-        return client.post("/api/v1/hint") {
-            contentType(ContentType.Application.Json)
-            setBody("""{"puzzle":"$puzzle"}""")
-        }
-    }
-
-    /**
-     * GET /api/v1/tutorials and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.tutorialsGet(): HttpResponse {
-        return client.get("/api/v1/tutorials")
-    }
-
-    /**
-     * GET /api/v1/tutorials/{id} and return the raw response.
-     */
-    suspend fun ApplicationTestBuilder.tutorialGet(id: String): HttpResponse {
-        return client.get("/api/v1/tutorials/$id")
-    }
-
-    // ── Application Setup ────────────────────────────────────
-
-    /**
-     * Configure the test application with all routes.
-     * Use this in testApplication { ... } blocks.
-     */
-    fun setupApplication(app: io.ktor.server.application.Application) {
-        app.module()
+/**
+ * POST a puzzle to /api/v1/solve and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.solvePost(puzzle: String): HttpResponse {
+    return client.post("/api/v1/solve") {
+        contentType(ContentType.Application.Json)
+        setBody("""{"puzzle":"$puzzle"}""")
     }
 }
+
+/**
+ * POST a puzzle to /api/v1/validate and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.validatePost(puzzle: String): HttpResponse {
+    return client.post("/api/v1/validate") {
+        contentType(ContentType.Application.Json)
+        setBody("""{"puzzle":"$puzzle"}""")
+    }
+}
+
+/**
+ * POST a puzzle to /api/v1/step-by-step and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.stepByStepPost(puzzle: String): HttpResponse {
+    return client.post("/api/v1/step-by-step") {
+        contentType(ContentType.Application.Json)
+        setBody("""{"puzzle":"$puzzle"}""")
+    }
+}
+
+/**
+ * POST a puzzle to /api/v1/hint and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.hintPost(puzzle: String): HttpResponse {
+    return client.post("/api/v1/hint") {
+        contentType(ContentType.Application.Json)
+        setBody("""{"puzzle":"$puzzle"}""")
+    }
+}
+
+/**
+ * GET /api/v1/tutorials and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.tutorialsGet(): HttpResponse {
+    return client.get("/api/v1/tutorials")
+}
+
+/**
+ * GET /api/v1/tutorials/{id} and return the raw response.
+ */
+suspend fun ApplicationTestBuilder.tutorialGet(id: String): HttpResponse {
+    return client.get("/api/v1/tutorials/$id")
+}
+
+// ── Application Setup ────────────────────────────────────
 
 /**
  * Run a test with the full application configured.

--- a/web/src/test/kotlin/will/sudoku/web/SolveRouteTest.kt
+++ b/web/src/test/kotlin/will/sudoku/web/SolveRouteTest.kt
@@ -1,0 +1,131 @@
+package will.sudoku.web
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests for POST /api/v1/solve
+ *
+ * Tests the solve endpoint end-to-end: valid puzzles, invalid inputs,
+ * edge cases.
+ *
+ * Refs #478
+ */
+class SolveRouteTest {
+
+    @Test
+    fun `solve valid puzzle returns solution`() = ktorTest {
+        val response = solvePost(SAMPLE_PUZZLE)
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertTrue(json.solved, "Should be solved")
+        assertNotNull(json.solution, "Should have a solution")
+        assertEquals(81, json.solution!!.length, "Solution should be 81 chars")
+        // Solution should have no dots (all cells filled)
+        assertFalse(json.solution!!.contains("."), "Solution should have no empty cells")
+        assertNull(json.error, "Should have no error")
+    }
+
+    @Test
+    fun `solve with wrong-length puzzle returns error`() = ktorTest {
+        val response = solvePost("12345")  // Too short
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertFalse(json.solved, "Should not be solved")
+        assertNotNull(json.error, "Should have an error message")
+        assertTrue(json.error!!.contains("81", ignoreCase = true),
+            "Error should mention expected length")
+    }
+
+    @Test
+    fun `solve with invalid characters returns error`() = ktorTest {
+        val response = solvePost("53007000060019500X098000060800060003400803001700020006060000280000419005000080079")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertFalse(json.solved, "Should not be solved")
+        assertNotNull(json.error, "Should have an error message")
+    }
+
+    @Test
+    fun `solve with duplicate in row returns error`() = ktorTest {
+        val response = solvePost(INVALID_PUZZLE)
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertFalse(json.solved, "Should not be solved with duplicate values")
+        assertNotNull(json.error, "Should have an error message")
+    }
+
+    @Test
+    fun `solve with all-zeros puzzle returns error`() = ktorTest {
+        val response = solvePost(EMPTY_PUZZLE)
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertFalse(json.solved, "Should not be solved with no clues")
+        assertNotNull(json.error, "Should have an error message")
+    }
+
+    @Test
+    fun `solve with too few clues returns error`() = ktorTest {
+        // Only 1 clue — below the 17-clue minimum
+        val puzzle = "000000000000000000000000000000000000000000000000000000000000000000000001000000000"
+        val response = solvePost(puzzle)
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertFalse(json.solved, "Should not be solved with too few clues")
+        assertNotNull(json.error, "Should have an error message")
+    }
+
+    @Test
+    fun `solve with metrics returns metrics in response`() = ktorTest {
+        val response = client.post("/api/v1/solve") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"puzzle":"${SAMPLE_PUZZLE}","includeMetrics":true}""")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertTrue(json.solved, "Should be solved")
+        assertNotNull(json.metrics, "Should include metrics")
+        assertTrue(json.metrics!!.solveTimeMs >= 0, "Solve time should be non-negative")
+        assertTrue(json.metrics!!.backtrackingCount >= 0, "Backtracking count should be non-negative")
+    }
+
+    @Test
+    fun `solve solution is valid sudoku`() = ktorTest {
+        val response = solvePost(SAMPLE_PUZZLE)
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<SolveResponse>(body)
+        assertTrue(json.solved)
+
+        val solution = json.solution!!
+        // Verify each row has digits 1-9
+        for (row in 0..8) {
+            val rowDigits = solution.substring(row * 9, (row + 1) * 9)
+                .map { it.digitToInt() }.toSet()
+            assertEquals(setOf(1, 2, 3, 4, 5, 6, 7, 8, 9), rowDigits,
+                "Row ${row + 1} should contain all digits 1-9")
+        }
+        // Verify each column has digits 1-9
+        for (col in 0..8) {
+            val colDigits = (0..8).map { solution[it * 9 + col].digitToInt() }.toSet()
+            assertEquals(setOf(1, 2, 3, 4, 5, 6, 7, 8, 9), colDigits,
+                "Column ${col + 1} should contain all digits 1-9")
+        }
+    }
+}

--- a/web/src/test/kotlin/will/sudoku/web/ValidateRouteTest.kt
+++ b/web/src/test/kotlin/will/sudoku/web/ValidateRouteTest.kt
@@ -1,0 +1,63 @@
+package will.sudoku.web
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests for POST /api/v1/validate
+ *
+ * Refs #479
+ */
+class ValidateRouteTest {
+
+    @Test
+    fun `validate valid puzzle returns valid true`() = ktorTest {
+        val response = validatePost(SAMPLE_PUZZLE)
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<ValidateResponse>(body)
+        assertTrue(json.valid, "Should be valid")
+        assertTrue(json.uniqueSolution ?: false, "Should have unique solution")
+        assertNull(json.error, "Should have no error")
+    }
+
+    @Test
+    fun `validate wrong-length puzzle returns 400 error`() = ktorTest {
+        val response = validatePost("12345")
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<ValidateResponse>(body)
+        assertFalse(json.valid, "Should not be valid")
+        assertNotNull(json.error, "Should have error")
+        assertTrue(json.error!!.contains("81"), "Error should mention 81 chars")
+    }
+
+    @Test
+    fun `validate invalid puzzle returns errors`() = ktorTest {
+        val response = validatePost(INVALID_PUZZLE)
+        // Invalid puzzle (duplicate 5s in row) returns error
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<ValidateResponse>(body)
+        assertFalse(json.valid, "Should not be valid with duplicates")
+    }
+
+    @Test
+    fun `validate with checkUniqueness false skips solution check`() = ktorTest {
+        val response = client.post("/api/v1/validate") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"puzzle":"$SAMPLE_PUZZLE","checkUniqueness":false}""")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        val json = testJson.decodeFromString<ValidateResponse>(body)
+        assertTrue(json.valid, "Should be valid")
+        assertNull(json.uniqueSolution, "Should not check uniqueness when disabled")
+        assertNull(json.solutionCount, "Should not report solution count when disabled")
+    }
+}


### PR DESCRIPTION
## Summary
Integration tests for POST /api/v1/validate endpoint.

Part of #431 (split 3/3) — closes #479. Depends on #477 (PR #494).

## Test Cases (4)
1. ✅ Valid puzzle → valid=true with unique solution
2. ✅ Wrong-length puzzle → 400 error
3. ✅ Invalid puzzle (duplicate values) → errors
4. ✅ checkUniqueness=false → skips solution count

## Testing
All 4 tests pass.