### PR TITLE
test: Tutorial route integration tests (Refs #480)

### DIFF
--- a/web/src/test/kotlin/will/sudoku/web/TutorialRouteTest.kt
+++ b/web/src/test/kotlin/will/sudoku/web/TutorialRouteTest.kt
@@ -1,0 +1,62 @@
+package will.sudoku.web
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration tests for tutorial-related routes.
+ *
+ * Note: GET /tutorials and GET /tutorials/{id} fail in testApplication due to
+ * TutorialLesson serializer conflict between main and test classpath
+ * (TutorialTestHelper.TutorialLesson @Serializable clashes with the main class).
+ * These routes are tested via the running server in production.
+ *
+ * Refs #480
+ */
+class TutorialRouteTest {
+
+    @Test
+    fun `GET tutorials nonexistent returns 404`() = ktorTest {
+        val response = tutorialGet("nonexistent-technique-xyz")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `GET tutorials quizzes white returns quiz data`() = ktorTest {
+        val response = client.get("/api/v1/tutorials/quizzes/white")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        assertTrue(body.contains("questions"), "Should contain questions array")
+        // Quiz questions contain answer fields
+        assertTrue(body.contains("answerCell"), "Should contain answerCell")
+        assertTrue(body.contains("answerValue"), "Should contain answerValue")
+    }
+
+    @Test
+    fun `GET tutorials quizzes nonexistent belt returns 404`() = ktorTest {
+        val response = client.get("/api/v1/tutorials/quizzes/nonexistent")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `GET tutorials quizzes list returns all quizzes`() = ktorTest {
+        val response = client.get("/api/v1/tutorials/quizzes")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        assertTrue(body.startsWith("["), "Should be a JSON array")
+    }
+
+    @Test
+    fun `GET tutorials practice list returns practice sets`() = ktorTest {
+        val response = client.get("/api/v1/tutorials/practice")
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val body = response.bodyAsText()
+        assertTrue(body.startsWith("[") || body.startsWith("{"), "Should be JSON")
+    }
+}


### PR DESCRIPTION
## Summary
Integration tests for tutorial-related routes.

Part of #430 (split 2/2) — closes #480. Depends on #477 (PR #494).

## Test Cases (5)
1. ✅ GET /tutorials/{nonexistent} → 404
2. ✅ GET /tutorials/quizzes/white → quiz with questions/answers
3. ✅ GET /tutorials/quizzes/{nonexistent} → 404
4. ✅ GET /tutorials/quizzes → all quizzes
5. ✅ GET /tutorials/practice → practice sets

## Known Issue
GET /tutorials and GET /tutorials/{id} can't be tested via testApplication due to TutorialLesson serializer conflict (main vs test classpath). Documented in test file. Filed as separate follow-up.