### PR TITLE
chore: remove legacy /api route block from Application.kt (Refs #458)

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/Application.kt
+++ b/web/src/main/kotlin/will/sudoku/web/Application.kt
@@ -137,14 +137,5 @@ fun Application.module() {
             }
             registerAllRoutes()
         }
-
-        // Legacy routes (unversioned) - DEPRECATED, will be removed in v2
-        route("api") {
-            intercept(ApplicationCallPipeline.Plugins) {
-                call.response.headers.append("X-API-Warn", "Deprecated: Use /api/v1/ instead. This endpoint will be removed in v2")
-                call.response.headers.append("Deprecation", "true")
-            }
-            registerAllRoutes()
-        }
     }
 }


### PR DESCRIPTION
## Summary
Removes the deprecated unversioned `/api` route block from Application.kt.

Part of #449 (Feature Scope Reduction) — closes #458.

## Changes
- Removed `route("api") { ... }` block that registered duplicate routes without version prefix
- All routes now exclusively served under `/api/v1/`

## Testing
- `./gradlew :web:test` — all tests pass
- `/api/v1/health` still works (via the versioned route)
- `/api/health` no longer returns duplicate responses