### PR TITLE
feat: Gradle JSON data validation task (Refs #481)

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -84,6 +84,83 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+// ============================================================
+// Build-time JSON data validation
+// Validates tutorial data files (lessons, quizzes, practice-puzzles)
+// ============================================================
+val validateJsonData by tasks.registering {
+    group = "verification"
+    description = "Validate JSON data files for required fields and correct structure"
+
+    val resourcesDir = file("src/main/resources/tutorials")
+
+    doLast {
+        val dataFiles = listOf(
+            Triple("lessons.json", "lesson", listOf("id", "title", "technique", "examplePuzzle")),
+            Triple("quizzes.json", "quiz", listOf("id", "belt", "questions")),
+            Triple("practice-puzzles.json", "practice puzzle", listOf("id", "technique", "puzzle"))
+        )
+
+        var totalErrors = 0
+        for ((fileName, dataType, requiredFields) in dataFiles) {
+            val jsonFile = File(resourcesDir, fileName)
+            println("Validating $dataType data from $fileName...")
+
+            if (!jsonFile.exists()) {
+                throw GradleException("$dataType file not found: ${jsonFile.absolutePath}")
+            }
+
+            val content = jsonFile.readText().trim()
+            if (!content.startsWith("[") || !content.endsWith("]")) {
+                throw GradleException("Expected JSON array in $fileName")
+            }
+
+            // Count objects and check fields
+            val entryPattern = Regex("\"id\"\\s*:\\s*\"([^\"]+)\"")
+            val ids = entryPattern.findAll(content).map { it.groupValues[1] }.toList()
+            println("  Found ${ids.size} $dataType entries")
+
+            // Check for duplicate IDs
+            val duplicates = ids.groupingBy { it }.eachCount().filter { it.value > 1 }.keys
+            if (duplicates.isNotEmpty()) {
+                println("  ERROR: Duplicate IDs: $duplicates")
+                totalErrors += duplicates.size
+            }
+
+            // Check required fields exist in file
+            for (field in requiredFields) {
+                if (!content.contains("\"$field\"")) {
+                    println("  ERROR: Required field '$field' not found in $fileName")
+                    totalErrors++
+                }
+            }
+
+            // Validate puzzle strings (81 chars, digits and 0s only)
+            val puzzlePattern = Regex("\"(?:examplePuzzle|puzzle)\"\\s*:\\s*\"([0-9]+)\"")
+            for (match in puzzlePattern.findAll(content)) {
+                val puzzle = match.groupValues[1]
+                if (puzzle.length != 81) {
+                    println("  ERROR: Puzzle string length ${puzzle.length} != 81")
+                    totalErrors++
+                }
+                if (puzzle.any { !it.isDigit() }) {
+                    println("  ERROR: Puzzle contains non-digit characters")
+                    totalErrors++
+                }
+            }
+        }
+
+        if (totalErrors > 0) {
+            throw GradleException("JSON validation failed: $totalErrors error(s) found")
+        }
+        println("✅ All JSON data files valid")
+    }
+}
+
+tasks.check {
+    dependsOn(validateJsonData)
+}
+
 tasks.test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
## Summary
Build-time validation infrastructure for JSON data files.

Part of #432/#433 (split 1/2) — closes #481.

## Changes
Added `validateJsonData` Gradle task to web module that validates:
- `lessons.json` (20 entries): id, title, technique, examplePuzzle
- `quizzes.json` (30 entries): id, belt, questions  
- `practice-puzzles.json` (50 entries): id, technique, puzzle

## Validations
- JSON array structure
- Required fields present
- Duplicate ID detection
- Puzzle string length (81 chars) + digit-only format

## Integration
- Wired into `check` task → runs on every `./gradlew check` or `./gradlew build`
- Build fails on validation errors

## Testing
`./gradlew :web:validateJsonData` → ✅ All valid
`./gradlew :web:check` → passes with validation included