### PR TITLE
chore: disable Gradle daemon and use in-process Kotlin compiler (Refs #502, #503)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,9 @@ org.gradle.workers.max=4
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.vfs.watch=false
 org.gradle.configuration-cache.problems=warn
+
+# Disable Gradle daemon to save memory
+org.gradle.daemon=false
+
+# Run Kotlin compiler in-process to avoid orphaned daemon processes
+kotlin.compiler.execution.strategy=in-process


### PR DESCRIPTION
## Summary
Disables the Gradle daemon and switches to in-process Kotlin compilation to reduce memory usage on this limited-RAM host.

Closes #502 and #503.

## Changes
- `org.gradle.daemon=false` — no background daemon consuming RAM between builds
- `kotlin.compiler.execution.strategy=in-process` — runs Kotlin compiler in the Gradle JVM instead of spawning a separate daemon, avoiding orphaned `kotlinc`/`kapt` processes

## Testing
Builds complete successfully: `./gradlew :kotlin:compileKotlin :web:compileKotlin` passes with both settings.