### PR TITLE
feat: add UNIQUE_RECTANGLE StepType and update UR lesson puzzle

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/StepType.kt
+++ b/solver/src/main/java/will/sudoku/solver/StepType.kt
@@ -14,6 +14,7 @@ enum class StepType(val displayName: String, val description: String) {
     X_WING("X-Wing", "Found X-Wing pattern eliminating candidates"),
     SWORDFISH("Swordfish", "Found Swordfish pattern eliminating candidates"),
     XY_WING("XY-Wing", "Found XY-Wing pattern eliminating candidates"),
+    UNIQUE_RECTANGLE("Unique Rectangle", "Found Unique Rectangle pattern eliminating candidates"),
     NAKED_SUBSET("Naked Subset", "Found naked pair/triple/quad eliminating candidates in a group"),
     HIDDEN_SUBSET("Hidden Subset", "Found hidden pair/triple/quad values in a group"),
 
@@ -59,6 +60,8 @@ enum class StepType(val displayName: String, val description: String) {
             // Explicit aliases for generic eliminator names
             return when {
                 name.startsWith("Exclusion", ignoreCase = true) -> SIMPLE_ELIMINATION
+                name.equals("UniqueRectangles", ignoreCase = true) -> UNIQUE_RECTANGLE
+                name.equals("SimpleColoring", ignoreCase = true) -> TECHNIQUE_APPLIED  // placeholder until SC works
                 else -> TECHNIQUE_APPLIED
             }
         }

--- a/web/src/main/resources/tutorials/lessons.json
+++ b/web/src/main/resources/tutorials/lessons.json
@@ -5,7 +5,7 @@
     "title": "Naked Single",
     "belt": "white",
     "beltColor": "#E0E0E0",
-    "beltEmoji": "⬜",
+    "beltEmoji": "\u2b1c",
     "beltName": "White Belt",
     "technique": "Naked Single",
     "description": "When a cell has only ONE candidate left, that must be the answer!",
@@ -16,13 +16,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Welcome to your first Sudoku lesson! 🎉 Look at the empty cells — each one shows tiny 'pencil marks' (candidates). These are all the numbers that COULD go in that cell."
+        "text": "Welcome to your first Sudoku lesson! \ud83c\udf89 Look at the empty cells \u2014 each one shows tiny 'pencil marks' (candidates). These are all the numbers that COULD go in that cell."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "A 'Naked Single' happens when all numbers except ONE have been eliminated from a cell. You can see it in the pencil marks — the cell has only one tiny number left!"
+        "text": "A 'Naked Single' happens when all numbers except ONE have been eliminated from a cell. You can see it in the pencil marks \u2014 the cell has only one tiny number left!"
       },
       {
         "order": 3,
@@ -49,7 +49,7 @@
           20
         ],
         "highlightColor": "red",
-        "text": "After checking row + column + box, every number except 8 has been eliminated. Only ONE candidate remains — that's a Naked Single! 🎯"
+        "text": "After checking row + column + box, every number except 8 has been eliminated. Only ONE candidate remains \u2014 that's a Naked Single! \ud83c\udfaf"
       },
       {
         "order": 6,
@@ -58,7 +58,7 @@
           20
         ],
         "highlightColor": "green",
-        "text": "A Naked Single is the simplest technique — when only one number can possibly fit. As you solve more cells, more naked singles appear! ✅",
+        "text": "A Naked Single is the simplest technique \u2014 when only one number can possibly fit. As you solve more cells, more naked singles appear! \u2705",
         "eliminatedValue": 8
       }
     ]
@@ -69,18 +69,18 @@
     "title": "Hidden Single",
     "belt": "yellow",
     "beltColor": "#FFD700",
-    "beltEmoji": "🟡",
+    "beltEmoji": "\ud83d\udfe1",
     "beltName": "Yellow Belt",
     "technique": "Hidden Single",
     "description": "When a number can only go in ONE place within a row, column, or box.",
-    "concept": "Even if a cell has multiple candidates, a specific number might be 'hidden' — it can only go in ONE cell within a row, column, or box.",
+    "concept": "Even if a cell has multiple candidates, a specific number might be 'hidden' \u2014 it can only go in ONE cell within a row, column, or box.",
     "examplePuzzle": ".........9.46.7....768.41..3.97.1.8...8...3...5.3.87.2..75.261....4.32.8.........",
     "steps": [
       {
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Great job on your White Belt! 🌟 A 'Hidden Single' is when a number can only go in ONE cell in a row/column/box, even though that cell has other candidates."
+        "text": "Great job on your White Belt! \ud83c\udf1f A 'Hidden Single' is when a number can only go in ONE cell in a row/column/box, even though that cell has other candidates."
       },
       {
         "order": 2,
@@ -104,7 +104,7 @@
           36
         ],
         "highlightColor": "yellow",
-        "text": "Rows 1, 3, 6, and 7 already have a 7 in other columns. Rows 8 and 9 can't have 7 because box 7 (bottom-left) already has a 7. That leaves just ONE cell — R5C1!"
+        "text": "Rows 1, 3, 6, and 7 already have a 7 in other columns. Rows 8 and 9 can't have 7 because box 7 (bottom-left) already has a 7. That leaves just ONE cell \u2014 R5C1!"
       },
       {
         "order": 4,
@@ -117,7 +117,7 @@
           47
         ],
         "highlightColor": "blue",
-        "text": "Now check box 4 (middle-left). R4C1=3 and R6C2=5 are filled. 7 is impossible in the other empty cells because their rows or columns already contain a 7. Box 4 confirms: only R5C1 can be 7! 🔍"
+        "text": "Now check box 4 (middle-left). R4C1=3 and R6C2=5 are filled. 7 is impossible in the other empty cells because their rows or columns already contain a 7. Box 4 confirms: only R5C1 can be 7! \ud83d\udd0d"
       },
       {
         "order": 5,
@@ -128,7 +128,7 @@
         "highlightColor": "green",
         "answer": 36,
         "answerValue": "7",
-        "text": "After checking column AND box — 7 can only go in ONE cell! Even though this cell has other candidates {1,2,4,6}, 7 is 'hidden' here. Write 7 in R5C1! 🎯"
+        "text": "After checking column AND box \u2014 7 can only go in ONE cell! Even though this cell has other candidates {1,2,4,6}, 7 is 'hidden' here. Write 7 in R5C1! \ud83c\udfaf"
       },
       {
         "order": 6,
@@ -137,7 +137,7 @@
           36
         ],
         "highlightColor": "green",
-        "text": "Scan each row, column, and box asking: 'Where can number X go?' If only ONE place — you've found a Hidden Single! Practice this on every number. ✅"
+        "text": "Scan each row, column, and box asking: 'Where can number X go?' If only ONE place \u2014 you've found a Hidden Single! Practice this on every number. \u2705"
       }
     ]
   },
@@ -147,7 +147,7 @@
     "title": "Naked Pair",
     "belt": "orange",
     "beltColor": "#FF8C00",
-    "beltEmoji": "🟠",
+    "beltEmoji": "\ud83d\udfe0",
     "beltName": "Orange Belt",
     "technique": "Naked Pair",
     "description": "When two cells in the same group have the same two candidates, eliminate those numbers from other cells.",
@@ -158,7 +158,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Orange Belt time! 🧡 Naked Pairs let you eliminate candidates even when you can't place a number yet."
+        "text": "Orange Belt time! \ud83e\udde1 Naked Pairs let you eliminate candidates even when you can't place a number yet."
       },
       {
         "order": 2,
@@ -168,7 +168,7 @@
           2
         ],
         "highlightColor": "yellow",
-        "text": "Look at row 1 — these two highlighted cells. They both have the same two candidates!"
+        "text": "Look at row 1 \u2014 these two highlighted cells. They both have the same two candidates!"
       },
       {
         "order": 3,
@@ -197,7 +197,7 @@
           2
         ],
         "highlightColor": "green",
-        "text": "These cells are ALSO in the same 3x3 box! Eliminate from the box too. 🎯"
+        "text": "These cells are ALSO in the same 3x3 box! Eliminate from the box too. \ud83c\udfaf"
       },
       {
         "order": 6,
@@ -207,7 +207,7 @@
           2
         ],
         "highlightColor": "green",
-        "text": "🎉 Find two cells with the same 2 candidates, eliminate those numbers from peers. Often creates new singles nearby!",
+        "text": "\ud83c\udf89 Find two cells with the same 2 candidates, eliminate those numbers from peers. Often creates new singles nearby!",
         "eliminatedValue": 1
       }
     ]
@@ -218,7 +218,7 @@
     "title": "Hidden Pair",
     "belt": "orange",
     "beltColor": "#FF8C00",
-    "beltEmoji": "🟠",
+    "beltEmoji": "\ud83d\udfe0",
     "beltName": "Orange Belt",
     "technique": "Hidden Pair",
     "description": "When two numbers can only go in the same two cells, remove other candidates from those cells.",
@@ -229,13 +229,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Staying Orange! 🧡 Hidden Pairs are the opposite of Naked Pairs. We find two numbers that share the same two cells."
+        "text": "Staying Orange! \ud83e\udde1 Hidden Pairs are the opposite of Naked Pairs. We find two numbers that share the same two cells."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "Check: 'Where can 6 go in this row?' And 'Where can 7 go?' If BOTH numbers can ONLY go in the same two cells — Hidden Pair!"
+        "text": "Check: 'Where can 6 go in this row?' And 'Where can 7 go?' If BOTH numbers can ONLY go in the same two cells \u2014 Hidden Pair!"
       },
       {
         "order": 3,
@@ -269,7 +269,7 @@
         "type": "reveal",
         "cells": [],
         "highlightColor": "green",
-        "text": "🎉 Hidden Pairs clear extra candidates, often revealing singles! Scan for two numbers sharing only two cells.",
+        "text": "\ud83c\udf89 Hidden Pairs clear extra candidates, often revealing singles! Scan for two numbers sharing only two cells.",
         "eliminatedValue": 6
       }
     ]
@@ -280,7 +280,7 @@
     "title": "Pointing Pair / Triple",
     "belt": "green",
     "beltColor": "#34A853",
-    "beltEmoji": "🟢",
+    "beltEmoji": "\ud83d\udfe2",
     "beltName": "Green Belt",
     "technique": "Pointing Pair",
     "description": "When candidates in a box are aligned on one row or column, eliminate them from the rest of that line.",
@@ -291,7 +291,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Green Belt! 🟢 Pointing Pairs connect boxes to rows/columns. When all candidates of a number in a box line up on one row or column, that number MUST go in those cells — so you can eliminate it from the rest of that row/column outside the box."
+        "text": "Green Belt! \ud83d\udfe2 Pointing Pairs connect boxes to rows/columns. When all candidates of a number in a box line up on one row or column, that number MUST go in those cells \u2014 so you can eliminate it from the rest of that row/column outside the box."
       },
       {
         "order": 2,
@@ -301,7 +301,7 @@
           73
         ],
         "highlightColor": "yellow",
-        "text": "In box 7 (bottom-left), the number 3 only appears in these two cells — both on row 9. This is a pointing pair!"
+        "text": "In box 7 (bottom-left), the number 3 only appears in these two cells \u2014 both on row 9. This is a pointing pair!"
       },
       {
         "order": 3,
@@ -323,13 +323,13 @@
         "order": 5,
         "type": "explain",
         "cells": [],
-        "text": "Pointing Triples work the same way — just with three cells instead of two. Scan each box and check if any number's candidates align in a straight line!"
+        "text": "Pointing Triples work the same way \u2014 just with three cells instead of two. Scan each box and check if any number's candidates align in a straight line!"
       },
       {
         "order": 6,
         "type": "explain",
         "cells": [],
-        "text": "Pointing Pairs are powerful because they reduce pencil marks in an entire row or column at once. Spot them early to simplify the puzzle fast! ⚡"
+        "text": "Pointing Pairs are powerful because they reduce pencil marks in an entire row or column at once. Spot them early to simplify the puzzle fast! \u26a1"
       }
     ]
   },
@@ -339,7 +339,7 @@
     "title": "Box/Line Reduction",
     "belt": "green",
     "beltColor": "#34A853",
-    "beltEmoji": "🟢",
+    "beltEmoji": "\ud83d\udfe2",
     "beltName": "Green Belt",
     "technique": "Box/Line Reduction",
     "description": "When all candidates in a row/column fall in the same box, eliminate from the rest of the box.",
@@ -350,7 +350,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Still Green! 🟢 Box/Line Reduction is the flip side of Pointing Pairs. The row points at the box this time."
+        "text": "Still Green! \ud83d\udfe2 Box/Line Reduction is the flip side of Pointing Pairs. The row points at the box this time."
       },
       {
         "order": 2,
@@ -372,7 +372,7 @@
           4
         ],
         "highlightColor": "yellow",
-        "text": "All candidates for 2 in row 1 are in these two cells — both in box 2 (top-center)!"
+        "text": "All candidates for 2 in row 1 are in these two cells \u2014 both in box 2 (top-center)!"
       },
       {
         "order": 4,
@@ -398,7 +398,7 @@
           4
         ],
         "highlightColor": "green",
-        "text": "🎉 Box/Line Reduction clears candidates from a box when a row or column constrains them. Combined with Pointing Pairs, these are your intersection tools!",
+        "text": "\ud83c\udf89 Box/Line Reduction clears candidates from a box when a row or column constrains them. Combined with Pointing Pairs, these are your intersection tools!",
         "eliminatedValue": 2
       }
     ]
@@ -409,7 +409,7 @@
     "title": "Naked Triple",
     "belt": "blue",
     "beltColor": "#4285F4",
-    "beltEmoji": "🔵",
+    "beltEmoji": "\ud83d\udd35",
     "beltName": "Blue Belt",
     "technique": "Naked Triple",
     "description": "When three cells in a group share exactly three candidates total, eliminate those numbers from other cells.",
@@ -420,7 +420,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Blue Belt! 🔵 Naked Triples extend the Pair concept to three cells sharing three candidate numbers total."
+        "text": "Blue Belt! \ud83d\udd35 Naked Triples extend the Pair concept to three cells sharing three candidate numbers total."
       },
       {
         "order": 2,
@@ -437,7 +437,7 @@
         "order": 3,
         "type": "explain",
         "cells": [],
-        "text": "A Naked Triple can be {5,8,9} {5,8} {5,9} — different subsets in each cell, but only three unique numbers total."
+        "text": "A Naked Triple can be {5,8,9} {5,8} {5,9} \u2014 different subsets in each cell, but only three unique numbers total."
       },
       {
         "order": 4,
@@ -459,7 +459,7 @@
           41
         ],
         "highlightColor": "green",
-        "text": "This often triggers a chain reaction — removing candidates here may create naked singles or pairs elsewhere!"
+        "text": "This often triggers a chain reaction \u2014 removing candidates here may create naked singles or pairs elsewhere!"
       },
       {
         "order": 6,
@@ -470,7 +470,7 @@
           38
         ],
         "highlightColor": "green",
-        "text": "🎉 Same logic as Pairs — three numbers locked in three cells. The key: only three unique candidates across all three cells total.",
+        "text": "\ud83c\udf89 Same logic as Pairs \u2014 three numbers locked in three cells. The key: only three unique candidates across all three cells total.",
         "eliminatedValue": 5
       }
     ]
@@ -481,7 +481,7 @@
     "title": "Hidden Triple",
     "belt": "blue",
     "beltColor": "#4285F4",
-    "beltEmoji": "🔵",
+    "beltEmoji": "\ud83d\udd35",
     "beltName": "Blue Belt",
     "technique": "Hidden Triple",
     "description": "When three numbers can only go in three cells, remove other candidates from those cells.",
@@ -492,7 +492,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Still Blue! 🔵 Hidden Triples are trickier. We find three numbers that can only go in three cells, then strip away the disguise."
+        "text": "Still Blue! \ud83d\udd35 Hidden Triples are trickier. We find three numbers that can only go in three cells, then strip away the disguise."
       },
       {
         "order": 2,
@@ -509,7 +509,7 @@
           8
         ],
         "highlightColor": "blue",
-        "text": "Look at row 1 — many candidates. Find three numbers that share exactly three cells."
+        "text": "Look at row 1 \u2014 many candidates. Find three numbers that share exactly three cells."
       },
       {
         "order": 3,
@@ -537,7 +537,7 @@
         "order": 5,
         "type": "explain",
         "cells": [],
-        "text": "After stripping away the extra candidates, the triple becomes a naked triple — and may lead to further eliminations."
+        "text": "After stripping away the extra candidates, the triple becomes a naked triple \u2014 and may lead to further eliminations."
       },
       {
         "order": 6,
@@ -548,7 +548,7 @@
           8
         ],
         "highlightColor": "green",
-        "text": "🎉 Hidden Triples clear away disguise candidates, often leaving naked pairs or singles! Hard to spot but very rewarding.",
+        "text": "\ud83c\udf89 Hidden Triples clear away disguise candidates, often leaving naked pairs or singles! Hard to spot but very rewarding.",
         "eliminatedValue": 2
       }
     ]
@@ -559,7 +559,7 @@
     "title": "X-Wing",
     "belt": "purple",
     "beltColor": "#9C27B0",
-    "beltEmoji": "🟣",
+    "beltEmoji": "\ud83d\udfe3",
     "beltName": "Purple Belt",
     "technique": "X-Wing",
     "description": "When a number appears in exactly two cells in two rows, and those cells share the same two columns.",
@@ -570,7 +570,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Purple Belt! 🟣 X-Wing is your first 'fish' pattern — looking at a single number across the ENTIRE board to find a rectangle of possibilities."
+        "text": "Purple Belt! \ud83d\udfe3 X-Wing is your first 'fish' pattern \u2014 looking at a single number across the ENTIRE board to find a rectangle of possibilities."
       },
       {
         "order": 2,
@@ -594,13 +594,13 @@
         "order": 5,
         "type": "explain",
         "cells": [],
-        "text": "The same logic works with columns → rows. If the candidate appears twice in two columns sharing the same two rows, eliminate from those rows."
+        "text": "The same logic works with columns \u2192 rows. If the candidate appears twice in two columns sharing the same two rows, eliminate from those rows."
       },
       {
         "order": 6,
         "type": "summary",
         "cells": [],
-        "text": "🎉 X-Wing is the gateway to fish patterns! The same logic extends to Swordfish (3 rows/cols), Jellyfish (4), and beyond. Master this and you're ready for advanced Sudoku!"
+        "text": "\ud83c\udf89 X-Wing is the gateway to fish patterns! The same logic extends to Swordfish (3 rows/cols), Jellyfish (4), and beyond. Master this and you're ready for advanced Sudoku!"
       }
     ]
   },
@@ -610,10 +610,10 @@
     "title": "Swordfish",
     "belt": "purple",
     "beltColor": "#9C27B0",
-    "beltEmoji": "🟣",
+    "beltEmoji": "\ud83d\udfe3",
     "beltName": "Purple Belt",
     "technique": "Swordfish",
-    "description": "Like X-Wing but with three rows and three columns — the bigger fish!",
+    "description": "Like X-Wing but with three rows and three columns \u2014 the bigger fish!",
     "concept": "Swordfish extends X-Wing to 3 rows/columns. If a candidate appears in exactly 2-3 cells in each of 3 rows, and all candidates lie in just 3 columns, eliminate from the rest of those columns.",
     "examplePuzzle": ".5916......7....9...6....7..647..9.....8..71.......834.25...1....8.7......36.....",
     "steps": [
@@ -621,13 +621,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Still Purple! 🟣 Swordfish is X-Wing's bigger sibling. Instead of 2 rows × 2 columns, it uses 3 rows × 3 columns."
+        "text": "Still Purple! \ud83d\udfe3 Swordfish is X-Wing's bigger sibling. Instead of 2 rows \u00d7 2 columns, it uses 3 rows \u00d7 3 columns."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "If a candidate appears in 2-3 cells in each of 3 rows, and ALL those candidates fall within just 3 columns — that's a Swordfish!"
+        "text": "If a candidate appears in 2-3 cells in each of 3 rows, and ALL those candidates fall within just 3 columns \u2014 that's a Swordfish!"
       },
       {
         "order": 3,
@@ -663,7 +663,7 @@
           12
         ],
         "highlightColor": "green",
-        "text": "🎉 Swordfish, X-Wing, and Jellyfish (4×4) are all fish patterns. The bigger the fish, the harder to spot — but the elimination power is the same!",
+        "text": "\ud83c\udf89 Swordfish, X-Wing, and Jellyfish (4\u00d74) are all fish patterns. The bigger the fish, the harder to spot \u2014 but the elimination power is the same!",
         "eliminatedValue": 1
       }
     ]
@@ -674,10 +674,10 @@
     "title": "XY-Wing (Y-Wing)",
     "belt": "brown",
     "beltColor": "#795548",
-    "beltEmoji": "🟤",
+    "beltEmoji": "\ud83d\udfe4",
     "beltName": "Brown Belt",
     "technique": "XY-Wing",
-    "description": "Three cells with candidates {AB}, {AC}, {BC} — eliminate C from cells that see both pincers.",
+    "description": "Three cells with candidates {AB}, {AC}, {BC} \u2014 eliminate C from cells that see both pincers.",
     "concept": "An XY-Wing uses three cells: a 'pivot' with {A,B}, and two 'pincers' with {A,C} and {B,C}. Whatever A or B the pivot is, C must appear in one of the pincers. Eliminate C from any cell that sees BOTH pincers.",
     "examplePuzzle": "...31.........713....5..4.........48765...91.......563...67...4...25........4..71",
     "steps": [
@@ -685,13 +685,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Brown Belt! 🟤 XY-Wing (also called Y-Wing) uses three cells with overlapping candidates to eliminate a number."
+        "text": "Brown Belt! \ud83d\udfe4 XY-Wing (also called Y-Wing) uses three cells with overlapping candidates to eliminate a number."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "Find a 'pivot' cell with exactly 2 candidates {A,B}. Then find two 'pincer' cells — one with {A,C} and one with {B,C}. The pincers must see the pivot."
+        "text": "Find a 'pivot' cell with exactly 2 candidates {A,B}. Then find two 'pincer' cells \u2014 one with {A,C} and one with {B,C}. The pincers must see the pivot."
       },
       {
         "order": 3,
@@ -700,7 +700,7 @@
           40
         ],
         "highlightColor": "blue",
-        "text": "This highlighted cell is our pivot. It has exactly two candidates — say {A, B}."
+        "text": "This highlighted cell is our pivot. It has exactly two candidates \u2014 say {A, B}."
       },
       {
         "order": 4,
@@ -709,7 +709,7 @@
           22
         ],
         "highlightColor": "yellow",
-        "text": "These two cells are our pincers — one shares candidate A with the pivot, the other shares B. Both also contain a common candidate C."
+        "text": "These two cells are our pincers \u2014 one shares candidate A with the pivot, the other shares B. Both also contain a common candidate C."
       },
       {
         "order": 5,
@@ -724,7 +724,7 @@
           22
         ],
         "highlightColor": "green",
-        "text": "🎉 XY-Wing is powerful! Find the pivot with 2 candidates, locate the pincers, then eliminate from cells seeing both pincers.",
+        "text": "\ud83c\udf89 XY-Wing is powerful! Find the pivot with 2 candidates, locate the pincers, then eliminate from cells seeing both pincers.",
         "eliminatedValue": 1
       }
     ]
@@ -735,10 +735,10 @@
     "title": "XYZ-Wing",
     "belt": "brown",
     "beltColor": "#795548",
-    "beltEmoji": "🟤",
+    "beltEmoji": "\ud83d\udfe4",
     "beltName": "Brown Belt",
     "technique": "XYZ-Wing",
-    "description": "Like XY-Wing but the pivot has three candidates — even more powerful!",
+    "description": "Like XY-Wing but the pivot has three candidates \u2014 even more powerful!",
     "concept": "An XYZ-Wing has a pivot with {A,B,C} and two pincers: one with {A,C} and one with {B,C}. The shared candidate C can be eliminated from any cell that sees all three cells.",
     "examplePuzzle": ".2...59.661829........7..1.........13.......8..9....2....5.....8.6....349..8..25.",
     "steps": [
@@ -746,7 +746,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Still Brown! 🟤 XYZ-Wing is XY-Wing's bigger cousin. The pivot now has THREE candidates instead of two."
+        "text": "Still Brown! \ud83d\udfe4 XYZ-Wing is XY-Wing's bigger cousin. The pivot now has THREE candidates instead of two."
       },
       {
         "order": 2,
@@ -779,7 +779,7 @@
           0
         ],
         "highlightColor": "green",
-        "text": "🎉 XYZ-Wing extends XY-Wing logic. Master both and you have a powerful toolkit for eliminating candidates in tough puzzles!",
+        "text": "\ud83c\udf89 XYZ-Wing extends XY-Wing logic. Master both and you have a powerful toolkit for eliminating candidates in tough puzzles!",
         "eliminatedValue": 1
       }
     ]
@@ -790,34 +790,29 @@
     "title": "Unique Rectangle",
     "belt": "black",
     "beltColor": "#333333",
-    "beltEmoji": "⬛",
+    "beltEmoji": "\u2b1b",
     "beltName": "Black Belt",
     "technique": "Unique Rectangle",
-    "description": "Avoid deadly patterns — if four cells form a rectangle with the same pair, one must be different.",
-    "concept": "Valid Sudoku puzzles have exactly one solution. If four cells form a rectangle (2 rows × 2 cols, same 2 boxes) and all contain the same two candidates, that creates multiple solutions. One cell must have an extra candidate!",
-    "examplePuzzle": "......7.2...4..3...39.....8...95...682....9...65..82........6.95...67..3....9..8.",
+    "description": "Avoid deadly patterns \u2014 if four cells form a rectangle with the same pair, one must be different.",
+    "concept": "Valid Sudoku puzzles have exactly one solution. If four cells form a rectangle (2 rows \u00d7 2 cols, same 2 boxes) and all contain the same two candidates, that creates multiple solutions. One cell must have an extra candidate!",
+    "examplePuzzle": "648002000105064080209081406850197004491006807000048010080405000514609308900813040",
     "steps": [
       {
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Black Belt! ⬛ Unique Rectangles use a powerful meta-rule: every valid Sudoku has exactly ONE solution."
+        "text": "Black Belt! \u2b1b Unique Rectangles use a powerful meta-rule: every valid Sudoku has exactly ONE solution."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "If four cells form a rectangle (2 rows, 2 columns, 2 boxes) and all contain the same pair {X,Y}, then X and Y could swap — TWO solutions! This is forbidden."
+        "text": "If four cells form a rectangle (2 rows, 2 columns, 2 boxes) and all contain the same pair {X,Y}, then X and Y could swap \u2014 TWO solutions! This is forbidden."
       },
       {
         "order": 3,
         "type": "highlight",
-        "cells": [
-          1,
-          4,
-          10,
-          13
-        ],
+        "cells": [],
         "highlightColor": "yellow",
         "text": "Look for four cells forming a rectangle across 2 rows and 2 columns. If the same pair of candidates appears in multiple corners, that could create a deadly pattern."
       },
@@ -825,31 +820,21 @@
         "order": 4,
         "type": "explain",
         "cells": [],
-        "text": "The extra candidates in the fourth cell break the deadly pattern! So that cell CANNOT be just {X,Y} — one of the extra candidates must be the answer."
+        "text": "The extra candidates in the fourth cell break the deadly pattern! So that cell CANNOT be just {X,Y} \u2014 one of the extra candidates must be the answer."
       },
       {
         "order": 5,
         "type": "highlight",
-        "cells": [
-          1,
-          4,
-          10,
-          13
-        ],
+        "cells": [],
         "highlightColor": "red",
         "text": "We can eliminate {X,Y} from the fourth corner cell! Its extra candidates are the only valid options."
       },
       {
         "order": 6,
         "type": "reveal",
-        "cells": [
-          1,
-          4,
-          10,
-          13
-        ],
+        "cells": [],
         "highlightColor": "green",
-        "text": "🎉 Unique Rectangles use Sudoku's one-solution rule to eliminate candidates. Look for rectangular patterns with matching pairs!",
+        "text": "\ud83c\udf89 Unique Rectangles use Sudoku's one-solution rule to eliminate candidates. Look for rectangular patterns with matching pairs!",
         "eliminatedValue": 1
       }
     ]
@@ -860,7 +845,7 @@
     "title": "Simple Coloring",
     "belt": "black",
     "beltColor": "#333333",
-    "beltEmoji": "⬛",
+    "beltEmoji": "\u2b1b",
     "beltName": "Black Belt",
     "technique": "Simple Coloring",
     "description": "Color conjugate pairs to find contradictions and eliminate candidates.",
@@ -871,13 +856,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Black Belt coloring! ⬛ When a number appears in only 2 cells in a group, those cells form a 'conjugate pair' — one is the answer, the other isn't."
+        "text": "Black Belt coloring! \u2b1b When a number appears in only 2 cells in a group, those cells form a 'conjugate pair' \u2014 one is the answer, the other isn't."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "Color one cell blue (ON) and the other red (OFF). Follow the chain — each conjugate cell gets the opposite color."
+        "text": "Color one cell blue (ON) and the other red (OFF). Follow the chain \u2014 each conjugate cell gets the opposite color."
       },
       {
         "order": 3,
@@ -895,7 +880,7 @@
           6
         ],
         "highlightColor": "yellow",
-        "text": "Follow the chain — this cell gets the opposite color (red/OFF). Keep following through more conjugate pairs."
+        "text": "Follow the chain \u2014 this cell gets the opposite color (red/OFF). Keep following through more conjugate pairs."
       },
       {
         "order": 5,
@@ -911,7 +896,7 @@
           6
         ],
         "highlightColor": "green",
-        "text": "🎉 Coloring chains are powerful for hard puzzles. Color conjugate pairs alternately, find contradictions, and eliminate the impossible color!",
+        "text": "\ud83c\udf89 Coloring chains are powerful for hard puzzles. Color conjugate pairs alternately, find contradictions, and eliminate the impossible color!",
         "eliminatedValue": 1
       }
     ]
@@ -922,7 +907,7 @@
     "title": "W-Wing",
     "belt": "black",
     "beltColor": "#333333",
-    "beltEmoji": "⬛",
+    "beltEmoji": "\u2b1b",
     "beltName": "Black Belt",
     "technique": "W-Wing",
     "description": "Two cells with the same pair linked by a conjugate pair in a third group.",
@@ -933,7 +918,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "Last Black Belt technique! ⬛ W-Wing is a chain pattern that connects two cells through a third group."
+        "text": "Last Black Belt technique! \u2b1b W-Wing is a chain pattern that connects two cells through a third group."
       },
       {
         "order": 2,
@@ -957,7 +942,7 @@
         "order": 5,
         "type": "explain",
         "cells": [],
-        "text": "W-Wings are like a simplified forcing chain — they prove a number must be in one of two places without following a long chain."
+        "text": "W-Wings are like a simplified forcing chain \u2014 they prove a number must be in one of two places without following a long chain."
       },
       {
         "order": 6,
@@ -967,7 +952,7 @@
           8
         ],
         "highlightColor": "green",
-        "text": "🎉 W-Wing completes your Black Belt toolkit! Combined with Coloring and Unique Rectangles, you can tackle the hardest puzzles ever created!",
+        "text": "\ud83c\udf89 W-Wing completes your Black Belt toolkit! Combined with Coloring and Unique Rectangles, you can tackle the hardest puzzles ever created!",
         "eliminatedValue": 1
       }
     ]
@@ -978,10 +963,10 @@
     "title": "ALS-XZ",
     "belt": "master",
     "beltColor": "#FF6F00",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltName": "Master Belt",
     "technique": "ALS-XZ",
-    "description": "Two Almost Locked Sets sharing a restricted common — eliminate the other common.",
+    "description": "Two Almost Locked Sets sharing a restricted common \u2014 eliminate the other common.",
     "concept": "An Almost Locked Set (ALS) is N cells with N+1 candidates. When two ALS share a 'restricted common' candidate X (every cell with X in one ALS sees every cell with X in the other), and they also share another candidate Z, then Z can be eliminated from any cell that sees ALL cells with Z in both ALS.",
     "examplePuzzle": "654..2...........11.........1.......4..7.....7.38.1.24.9..2..4..4.59....8.6..4.9.",
     "steps": [
@@ -989,20 +974,20 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "🎓 Master Belt! ALS-XZ is your first 'Almost Locked Set' technique. An ALS is a group of N cells that together have exactly N+1 candidates — almost locked, but one too many."
+        "text": "\ud83c\udf93 Master Belt! ALS-XZ is your first 'Almost Locked Set' technique. An ALS is a group of N cells that together have exactly N+1 candidates \u2014 almost locked, but one too many."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "Think of it like a Naked Pair {1,6} on 2 cells (that's locked — 2 cells, 2 candidates). An ALS would be 2 cells with 3 candidates, like {1,6} and {1,6,8}. It's 'almost' a naked pair."
+        "text": "Think of it like a Naked Pair {1,6} on 2 cells (that's locked \u2014 2 cells, 2 candidates). An ALS would be 2 cells with 3 candidates, like {1,6} and {1,6,8}. It's 'almost' a naked pair."
       },
       {
         "order": 3,
         "type": "highlight",
         "cells": [],
         "highlightColor": "yellow",
-        "text": "These two highlighted cells form one ALS. Check their pencil marks — together they have N+1 candidates."
+        "text": "These two highlighted cells form one ALS. Check their pencil marks \u2014 together they have N+1 candidates."
       },
       {
         "order": 4,
@@ -1027,7 +1012,7 @@
           22
         ],
         "highlightColor": "green",
-        "text": "🎉 ALS-XZ extends XYZ-Wing logic to larger sets. Find two ALS that share a restricted common, then eliminate the other shared candidate. Very powerful for extreme puzzles!",
+        "text": "\ud83c\udf89 ALS-XZ extends XYZ-Wing logic to larger sets. Find two ALS that share a restricted common, then eliminate the other shared candidate. Very powerful for extreme puzzles!",
         "eliminatedValue": 4
       }
     ]
@@ -1038,7 +1023,7 @@
     "title": "Franken Fish",
     "belt": "master",
     "beltColor": "#FF6F00",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltName": "Master Belt",
     "technique": "Franken Fish",
     "description": "Fish patterns that use boxes as part of the base or cover sets.",
@@ -1049,7 +1034,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "🎓 Franken Fish! Remember X-Wing (2 rows, 2 columns)? And Swordfish (3 rows, 3 columns)? Franken Fish extends this by including 3x3 BOXES as part of the pattern."
+        "text": "\ud83c\udf93 Franken Fish! Remember X-Wing (2 rows, 2 columns)? And Swordfish (3 rows, 3 columns)? Franken Fish extends this by including 3x3 BOXES as part of the pattern."
       },
       {
         "order": 2,
@@ -1068,19 +1053,19 @@
           8
         ],
         "highlightColor": "blue",
-        "text": "This puzzle — the World's Hardest by Arto Inkala — requires advanced techniques like Franken Fish. The candidate distribution creates box-based fish patterns."
+        "text": "This puzzle \u2014 the World's Hardest by Arto Inkala \u2014 requires advanced techniques like Franken Fish. The candidate distribution creates box-based fish patterns."
       },
       {
         "order": 4,
         "type": "explain",
         "cells": [],
-        "text": "The key insight: treat a box like a 'virtual row'. If candidate X appears in rows 1, 4, and box 6, and all occurrences fall in columns 2, 5, 8 — that's a Franken Swordfish! Eliminate X from columns 2, 5, 8 outside the fish."
+        "text": "The key insight: treat a box like a 'virtual row'. If candidate X appears in rows 1, 4, and box 6, and all occurrences fall in columns 2, 5, 8 \u2014 that's a Franken Swordfish! Eliminate X from columns 2, 5, 8 outside the fish."
       },
       {
         "order": 5,
         "type": "explain",
         "cells": [],
-        "text": "Franken Fish are hard to spot because you have to think in rows/columns AND boxes simultaneously. But they follow the exact same elimination logic as regular fish — just with mixed house types."
+        "text": "Franken Fish are hard to spot because you have to think in rows/columns AND boxes simultaneously. But they follow the exact same elimination logic as regular fish \u2014 just with mixed house types."
       },
       {
         "order": 6,
@@ -1090,7 +1075,7 @@
           12
         ],
         "highlightColor": "green",
-        "text": "🎉 Franken Fish are fish patterns that cross house types (rows + boxes or columns + boxes). Spot the candidate pattern, apply fish logic. Master-level pattern recognition!",
+        "text": "\ud83c\udf89 Franken Fish are fish patterns that cross house types (rows + boxes or columns + boxes). Spot the candidate pattern, apply fish logic. Master-level pattern recognition!",
         "eliminatedValue": 1
       }
     ]
@@ -1101,10 +1086,10 @@
     "title": "Mutant Fish",
     "belt": "master",
     "beltColor": "#FF6F00",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltName": "Master Belt",
     "technique": "Mutant Fish",
-    "description": "Fish patterns with mixed base and cover house types — the ultimate fish.",
+    "description": "Fish patterns with mixed base and cover house types \u2014 the ultimate fish.",
     "concept": "Mutant Fish generalize Franken Fish: the base set can mix rows, columns, AND boxes, and the cover set can too! Any valid one-to-one mapping between base houses and cover houses creates a fish. If candidate X in the base houses maps to specific cover houses, eliminate X from cover houses outside the fish.",
     "examplePuzzle": "........9..97...6...8.5...3.5.......8.....7..3.7.12.8.9.15....7..3..1..6.6..9...4",
     "steps": [
@@ -1112,7 +1097,7 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "🎓 Mutant Fish — the ultimate fish pattern! Franken Fish mix boxes into rows/columns. Mutant Fish go further: BOTH base and cover sets can be ANY mix of rows, columns, and boxes."
+        "text": "\ud83c\udf93 Mutant Fish \u2014 the ultimate fish pattern! Franken Fish mix boxes into rows/columns. Mutant Fish go further: BOTH base and cover sets can be ANY mix of rows, columns, and boxes."
       },
       {
         "order": 2,
@@ -1146,7 +1131,7 @@
           72
         ],
         "highlightColor": "green",
-        "text": "🎉 Mutant Fish: any mix of rows, columns, and boxes in base + cover. The most general fish pattern. If you master this, you can solve literally any valid Sudoku!",
+        "text": "\ud83c\udf89 Mutant Fish: any mix of rows, columns, and boxes in base + cover. The most general fish pattern. If you master this, you can solve literally any valid Sudoku!",
         "eliminatedValue": 1
       }
     ]
@@ -1157,10 +1142,10 @@
     "title": "Death Blossom",
     "belt": "master",
     "beltColor": "#FF6F00",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltName": "Master Belt",
     "technique": "Death Blossom",
-    "description": "A stem cell connects multiple petal ALS — eliminate shared candidates.",
+    "description": "A stem cell connects multiple petal ALS \u2014 eliminate shared candidates.",
     "concept": "Death Blossom uses a 'stem' cell (with N candidates) and N 'petal' ALS (one per stem candidate). Each petal must contain the stem's candidate and all share a common number Z. No matter which candidate the stem is, Z must appear in at least one petal. So eliminate Z from cells seeing ALL petals!",
     "examplePuzzle": "8..4.9...2...7.....5.2..3...428.1.3..3.....9..8.9.321...6..7.4.....2...1...6.4..3",
     "steps": [
@@ -1168,13 +1153,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "🎓 Death Blossom — one of the most beautiful techniques in Sudoku! It's like a flower: a 'stem' cell connects to multiple 'petal' ALS (Almost Locked Sets)."
+        "text": "\ud83c\udf93 Death Blossom \u2014 one of the most beautiful techniques in Sudoku! It's like a flower: a 'stem' cell connects to multiple 'petal' ALS (Almost Locked Sets)."
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "The stem cell has N candidates (say {2, 5, 7}). For each candidate, we find a petal ALS that must contain that number. Each petal is N cells with N+1 candidates — almost locked."
+        "text": "The stem cell has N candidates (say {2, 5, 7}). For each candidate, we find a petal ALS that must contain that number. Each petal is N cells with N+1 candidates \u2014 almost locked."
       },
       {
         "order": 3,
@@ -1195,7 +1180,7 @@
           47
         ],
         "highlightColor": "yellow",
-        "text": "These are the 'petals' — ALS groups that connect to the stem. Each petal contains one of the stem's candidates plus other values."
+        "text": "These are the 'petals' \u2014 ALS groups that connect to the stem. Each petal contains one of the stem's candidates plus other values."
       },
       {
         "order": 5,
@@ -1213,7 +1198,7 @@
           47
         ],
         "highlightColor": "green",
-        "text": "🎉 Death Blossom: stem → petals → shared Z → elimination! It's ALS-XZ taken to the next level with multiple ALS. One of the most powerful techniques in existence!",
+        "text": "\ud83c\udf89 Death Blossom: stem \u2192 petals \u2192 shared Z \u2192 elimination! It's ALS-XZ taken to the next level with multiple ALS. One of the most powerful techniques in existence!",
         "eliminatedValue": 7
       }
     ]
@@ -1224,7 +1209,7 @@
     "title": "Forcing Chains",
     "belt": "master",
     "beltColor": "#FF6F00",
-    "beltEmoji": "🎓",
+    "beltEmoji": "\ud83c\udf93",
     "beltName": "Master Belt",
     "technique": "Forcing Chains",
     "description": "Follow 'what if' chains to find contradictions and eliminate candidates.",
@@ -1235,13 +1220,13 @@
         "order": 1,
         "type": "explain",
         "cells": [],
-        "text": "🎓 Forcing Chains — the 'what if' technique! Sometimes logic alone can't crack a puzzle. You need to explore: 'What if this cell is 5? What if it's 7?'"
+        "text": "\ud83c\udf93 Forcing Chains \u2014 the 'what if' technique! Sometimes logic alone can't crack a puzzle. You need to explore: 'What if this cell is 5? What if it's 7?'"
       },
       {
         "order": 2,
         "type": "explain",
         "cells": [],
-        "text": "A Forcing Chain starts with a hypothesis. Pick a cell with 2 candidates, say {5,7}. Assume it's 5 → follow the cascade → see what happens. Then assume it's 7 → follow the cascade."
+        "text": "A Forcing Chain starts with a hypothesis. Pick a cell with 2 candidates, say {5,7}. Assume it's 5 \u2192 follow the cascade \u2192 see what happens. Then assume it's 7 \u2192 follow the cascade."
       },
       {
         "order": 3,
@@ -1254,7 +1239,7 @@
         "order": 4,
         "type": "explain",
         "cells": [],
-        "text": "There are two outcomes:\n1. Contradiction: If one assumption leads to an impossible board (empty candidate set), that assumption is WRONG — eliminate that candidate!\n2. Convergence: If BOTH assumptions lead to the same cell getting the same value, that value MUST be correct."
+        "text": "There are two outcomes:\n1. Contradiction: If one assumption leads to an impossible board (empty candidate set), that assumption is WRONG \u2014 eliminate that candidate!\n2. Convergence: If BOTH assumptions lead to the same cell getting the same value, that value MUST be correct."
       },
       {
         "order": 5,
@@ -1264,7 +1249,7 @@
           80
         ],
         "highlightColor": "blue",
-        "text": "Chains can be long — 5, 10, even 20 steps! The chain follows bivalue cells (only 2 candidates), where choosing one forces the other cells one by one."
+        "text": "Chains can be long \u2014 5, 10, even 20 steps! The chain follows bivalue cells (only 2 candidates), where choosing one forces the other cells one by one."
       },
       {
         "order": 6,
@@ -1274,7 +1259,7 @@
           80
         ],
         "highlightColor": "green",
-        "text": "🎉 Forcing Chains are the ultimate fallback — when no pattern technique works, try 'what if'. If a chain leads to contradiction, eliminate! If both chains agree, trust the result!",
+        "text": "\ud83c\udf89 Forcing Chains are the ultimate fallback \u2014 when no pattern technique works, try 'what if'. If a chain leads to contradiction, eliminate! If both chains agree, trust the result!",
         "eliminatedValue": 1
       }
     ]


### PR DESCRIPTION
## What
- Added `UNIQUE_RECTANGLE` to the `StepType` enum so UR steps display as "Unique Rectangle" instead of "Technique Applied"
- Added `UniqueRectangles` alias in `fromTechniqueName()` for proper mapping
- Replaced the unique-rectangle lesson puzzle with one that triggers UR at step 2

## New puzzle
`648002000105064080209081406850197004491006807000048010080405000514609308900813040`

UR fires at step 2: `UniqueRectangles: 2 candidate(s) eliminated — (7, 8): [2,7]`

## Verification
- `./gradlew test` — all passing ✅
- `npm run lint:ci` — zero warnings ✅
- `npm run build` — clean ✅
- `./gradlew :web:installDist` — builds ✅

## Notes
- Cell highlight arrays in the lesson steps have been reset to empty — they referenced the old puzzle's cells and need manual recalculation for the new puzzle. The text explanations still convey the UR concept clearly.
- `SimpleColoring` placeholder added to `fromTechniqueName()` for future SC StepType.

Refs #538