### PR TITLE
feat: add early-termination mode and VERY_HARD difficulty to PuzzleCataloger

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/DifficultyRater.kt
+++ b/solver/src/main/java/will/sudoku/solver/DifficultyRater.kt
@@ -30,7 +30,8 @@ object DifficultyRater {
         MEDIUM(2, "Medium", "Hidden singles required"),
         HARD(3, "Hard", "Naked/hidden subsets required"),
         EXPERT(4, "Expert", "X-Wing technique required"),
-        MASTER(5, "Master", "Requires backtracking");
+        VERY_HARD(5, "Very Hard", "Advanced techniques beyond X-Wing"),
+        MASTER(6, "Master", "Requires backtracking");
 
         override fun toString(): String = displayName
     }

--- a/solver/src/main/java/will/sudoku/solver/PuzzleCataloger.kt
+++ b/solver/src/main/java/will/sudoku/solver/PuzzleCataloger.kt
@@ -106,10 +106,12 @@ object PuzzleCataloger {
     /**
      * Generate and catalog puzzles.
      *
-     * @param count Number of puzzles to generate
+     * @param count Number of puzzles to generate (max with --stop-after-first)
      * @param difficulty Difficulty level (harder = more techniques used)
      * @param targetTechnique If set, only collect puzzles that use this technique
      * @param requireTechnique If true, verify the puzzle CANNOT be solved without the target technique
+     * @param stopAfterFirst If true, stop as soon as a matching puzzle is found
+     * @param maxAttempts Maximum puzzles to generate when stopAfterFirst is true (default: 10000)
      * @param startSeed Starting seed for reproducibility
      * @return CatalogResult with entries grouped by technique
      */
@@ -118,6 +120,8 @@ object PuzzleCataloger {
         difficulty: DifficultyRater.Level = DifficultyRater.Level.EXPERT,
         targetTechnique: String? = null,
         requireTechnique: Boolean = false,
+        stopAfterFirst: Boolean = false,
+        maxAttempts: Int = 10000,
         startSeed: Long = 1
     ): CatalogResult {
         val byTechnique = mutableMapOf<String, MutableList<CatalogEntry>>()
@@ -136,7 +140,9 @@ object PuzzleCataloger {
             Solver(SolverConfig.withoutTechnique(targetStepType))
         } else null
 
-        for (i in 0 until count) {
+        val effectiveCount = if (stopAfterFirst) maxAttempts else count
+
+        for (i in 0 until effectiveCount) {
             val seed = startSeed + i
 
             // Generate puzzle
@@ -196,10 +202,20 @@ object PuzzleCataloger {
             for (tech in techniques) {
                 byTechnique.getOrPut(tech) { mutableListOf() }.add(entry)
             }
+
+            // Early termination: stop as soon as a matching puzzle is found
+            if (stopAfterFirst) {
+                return CatalogResult(
+                    totalGenerated = i + 1,
+                    totalSolved = totalSolved,
+                    byTechnique = byTechnique,
+                    unmatched = unmatched
+                )
+            }
         }
 
         return CatalogResult(
-            totalGenerated = count,
+            totalGenerated = if (stopAfterFirst) effectiveCount else count,
             totalSolved = totalSolved,
             byTechnique = byTechnique,
             unmatched = unmatched

--- a/solver/src/main/java/will/sudoku/solver/PuzzleCatalogerCli.kt
+++ b/solver/src/main/java/will/sudoku/solver/PuzzleCatalogerCli.kt
@@ -13,6 +13,8 @@ fun main(args: Array<String>) {
     var difficulty = DifficultyRater.Level.EXPERT
     var targetTechnique: String? = null
     var requireTechnique = false
+    var stopAfterFirst = false
+    var maxAttempts = 10000
     var startSeed = 1L
 
     // Parse args
@@ -26,12 +28,15 @@ fun main(args: Array<String>) {
                     "MEDIUM" -> DifficultyRater.Level.MEDIUM
                     "HARD" -> DifficultyRater.Level.HARD
                     "EXPERT" -> DifficultyRater.Level.EXPERT
+                    "VERY_HARD" -> DifficultyRater.Level.VERY_HARD
                     "MASTER" -> DifficultyRater.Level.MASTER
                     else -> difficulty
                 }
             }
             "--technique" -> { targetTechnique = args[++i] }
             "--require" -> { requireTechnique = true }
+            "--stop-after-first" -> { stopAfterFirst = true }
+            "--max-attempts" -> { maxAttempts = args[++i].toIntOrNull() ?: maxAttempts }
             "--seed" -> { startSeed = args[++i].toLongOrNull() ?: startSeed }
             "--help" -> {
                 println("""
@@ -41,9 +46,11 @@ fun main(args: Array<String>) {
                     
                     Options:
                       --count N          Number of puzzles to generate (default: 100)
-                      --difficulty LEVEL  EASY, MEDIUM, HARD, EXPERT, MASTER (default: EXPERT)
+                      --difficulty LEVEL  EASY, MEDIUM, HARD, EXPERT, VERY_HARD, MASTER (default: EXPERT)
                       --technique NAME    Target technique to find (default: all)
                       --require           Only return puzzles that REQUIRE the technique
+                      --stop-after-first  Stop as soon as a matching puzzle is found
+                      --max-attempts N    Max puzzles to generate with --stop-after-first (default: 10000)
                       --seed N            Starting seed (default: 1)
                       --help              Show this help
                     
@@ -59,6 +66,12 @@ fun main(args: Array<String>) {
                       Find 50 puzzles requiring Simple Coloring:
                         --count 50 --technique SIMPLE_COLORING --require --difficulty MASTER
                     
+                      Find first puzzle requiring Unique Rectangles (stop early):
+                        --technique UNIQUE_RECTANGLES --require --stop-after-first --difficulty VERY_HARD
+                    
+                      Find first puzzle requiring Simple Coloring with safety limit:
+                        --technique SIMPLE_COLORING --require --stop-after-first --max-attempts 5000 --difficulty VERY_HARD
+                    
                       Catalog ALL techniques across 1000 MASTER puzzles:
                         --count 1000 --difficulty MASTER
                 """.trimIndent())
@@ -71,6 +84,7 @@ fun main(args: Array<String>) {
     println("PuzzleCataloger")
     println("─".repeat(50))
     println("Count: $count, Difficulty: $difficulty")
+    if (stopAfterFirst) println("Stop after first: true (max attempts: $maxAttempts)")
     if (targetTechnique != null) {
         println("Target: $targetTechnique")
         println("Required: $requireTechnique")
@@ -85,6 +99,8 @@ fun main(args: Array<String>) {
         difficulty = difficulty,
         targetTechnique = targetTechnique,
         requireTechnique = requireTechnique,
+        stopAfterFirst = stopAfterFirst,
+        maxAttempts = maxAttempts,
         startSeed = startSeed
     )
     val elapsed = System.currentTimeMillis() - startTime

--- a/solver/src/main/java/will/sudoku/solver/PuzzleGenerator.kt
+++ b/solver/src/main/java/will/sudoku/solver/PuzzleGenerator.kt
@@ -85,6 +85,7 @@ object PuzzleGenerator {
             DifficultyRater.Level.MEDIUM -> 45    // 36 cells remaining
             DifficultyRater.Level.HARD -> 52      // 29 cells remaining
             DifficultyRater.Level.EXPERT -> 56    // 25 cells remaining
+            DifficultyRater.Level.VERY_HARD -> 58    // 23 cells remaining
             DifficultyRater.Level.MASTER -> 60    // 21 cells remaining
         }
     }

--- a/solver/src/test/java/will/sudoku/solver/DifficultyRaterTest.kt
+++ b/solver/src/test/java/will/sudoku/solver/DifficultyRaterTest.kt
@@ -173,6 +173,7 @@ class DifficultyRaterTest {
         assertThat(DifficultyRater.Level.MEDIUM.value).isEqualTo(2)
         assertThat(DifficultyRater.Level.HARD.value).isEqualTo(3)
         assertThat(DifficultyRater.Level.EXPERT.value).isEqualTo(4)
-        assertThat(DifficultyRater.Level.MASTER.value).isEqualTo(5)
+        assertThat(DifficultyRater.Level.VERY_HARD.value).isEqualTo(5)
+        assertThat(DifficultyRater.Level.MASTER.value).isEqualTo(6)
     }
 }


### PR DESCRIPTION
## What
- Added `VERY_HARD` to `DifficultyRater.Level` (value=5, between EXPERT and MASTER)
- Updated `PuzzleGenerator.getCellsToRemove()` with VERY_HARD (58 cells removed → 23 remaining)
- Added `--stop-after-first` CLI flag: exits immediately when a matching puzzle is found
- Added `--max-attempts` CLI safety limit (default: 10000) for `--stop-after-first`
- Updated `PuzzleCataloger.catalog()` with new `stopAfterFirst`/ `maxAttempts` params
- Updated `DifficultyRaterTest` for new enum values

## Usage
```bash
# Find first puzzle that uses UR (stop early)
./gradlew :solver:run --args="--technique UNIQUE_RECTANGLES --stop-after-first --difficulty VERY_HARD"

# Find first puzzle REQUIRING a technique with safety limit
./gradlew :solver:run --args="--technique X_WING --require --stop-after-first --max-attempts 5000 --difficulty VERY_HARD"
```

## Verification
- `./gradlew test` — all passing ✅
- `npm run lint:ci` — zero warnings ✅
- `npm run build` — clean ✅
- `./gradlew :web:installDist` — builds ✅

## Notes
- Existing behavior unchanged when flags are not used
- `--help` output updated with new flags

Refs #542