### PR TITLE
docs: add user guide — Getting Started, Game Modes, Solving Interface

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -70,3 +70,54 @@ Practice specific techniques with curated puzzle sets:
 4. Solve puzzles filtered to challenge that specific skill
 
 Practice puzzles are grouped by belt level — complete tutorials first to unlock practice sets.
+
+---
+
+## Solving Interface
+
+### Grid Controls
+
+- **Select a cell** — tap any empty or filled cell
+- **Enter a number** — tap a number on the pad (bottom) or press 1-9 on keyboard
+- **Clear a cell** — select it and press Delete/Backspace, or tap the ✕ button
+- **Navigate** — use arrow keys or swipe to move between cells
+
+### Pencil Marks
+
+Pencil marks let you note possible candidates in a cell:
+
+1. Select a cell
+2. Toggle pencil mode (✏️ button or keyboard shortcut)
+3. Enter numbers — they appear as small notes instead of final answers
+4. Toggle off to return to normal entry mode
+
+### Hints
+
+Stuck? Tap the 💡 **Hint** button for a guided next step:
+
+- The hint highlights relevant cells and explains the technique to use
+- Follow the hint to learn how the technique works in context
+- Hints are part of the learning experience — use them freely!
+
+### Error Checking
+
+The app validates your puzzle as you go:
+- **Conflict highlighting** — cells with duplicate numbers in a row/column/box are flagged
+- **Completion detection** — the app knows when you've solved the puzzle
+- No time penalty for mistakes — this is a learning tool, not a race
+
+### Timer
+
+A timer tracks how long you've been solving. It's informational only — no pressure!
+
+### Keyboard Shortcuts
+
+| Key | Action |
+|-----|--------|
+| `↑ ↓ ← →` | Navigate between cells |
+| `1-9` | Enter a number |
+| `Delete` / `⌫` | Clear cell |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Y` | Redo |
+| `?` | Show keyboard shortcuts |
+| `Esc` | Deselect cell |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,34 @@
+# Sudoku Dojo — User Guide
+
+## Getting Started
+
+### What is Sudoku Dojo?
+
+Sudoku Dojo is an educational Sudoku platform that teaches you solving techniques through interactive tutorials, belt-rank progression, and practice puzzles. Unlike regular Sudoku apps, it doesn't just check your answers — it teaches you *how* to solve puzzles step by step.
+
+### How to Access
+
+**Web App:** Open your browser and navigate to the Sudoku Dojo URL.
+
+**Install as App (PWA):**
+- **Chrome/Edge:** Click the install icon (⬇️) in the address bar, or go to Menu → "Install Sudoku Dojo"
+- **Safari (iOS):** Tap the Share button (⬆️), then "Add to Home Screen"
+- **Android:** Tap the menu (⋮) in your browser, then "Add to Home Screen"
+
+Once installed, Sudoku Dojo works like a native app — launch it from your home screen.
+
+### First Puzzle Walkthrough
+
+1. **Open Sudoku Dojo** — you'll see the main grid with some numbers pre-filled
+2. **Select a cell** — tap any empty cell to select it
+3. **Enter a number** — use the number pad (bottom) or keyboard (1-9) to fill in your answer
+4. **Use hints** — stuck? Tap the 💡 hint button for a guided next step
+5. **Check your work** — the app validates your puzzle as you go
+6. **Complete the puzzle** — fill all 81 cells correctly to win!
+
+### What's Next?
+
+Once you're comfortable with basic solving, explore:
+- **Tutorials** — learn 21+ advanced techniques with guided lessons
+- **Practice Mode** — solve puzzles that require specific techniques
+- **Belt Progression** — unlock belts as you master techniques

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -32,3 +32,41 @@ Once you're comfortable with basic solving, explore:
 - **Tutorials** — learn 21+ advanced techniques with guided lessons
 - **Practice Mode** — solve puzzles that require specific techniques
 - **Belt Progression** — unlock belts as you master techniques
+
+---
+
+## Game Modes
+
+### Free Play
+
+Generate a new puzzle by selecting a difficulty level:
+
+| Difficulty | Givens | Description |
+|-----------|--------|-------------|
+| **Easy** | 36-45 | Perfect for beginners |
+| **Medium** | 30-35 | A gentle challenge |
+| **Hard** | 26-29 | Requires some technique |
+| **Expert** | 22-25 | Advanced strategies needed |
+| **Master** | 17-21 | For the truly dedicated |
+
+Tap **Generate** to create a new puzzle, then solve it at your own pace.
+
+### Import
+
+Have a puzzle from a book, newspaper, or website? Import it:
+
+1. Tap the **Import** button
+2. Paste an 81-character puzzle string (use `0` or `.` for empty cells)
+   - Example: `000000030002090500080706004900054006...`
+3. Tap **Load** to start solving
+
+### Practice Mode
+
+Practice specific techniques with curated puzzle sets:
+
+1. Open the **Tutorial** menu
+2. Select a technique you've learned
+3. Choose **Practice** to get puzzles that require that technique
+4. Solve puzzles filtered to challenge that specific skill
+
+Practice puzzles are grouped by belt level — complete tutorials first to unlock practice sets.

--- a/solver/src/main/java/will/sudoku/solver/SimpleColoringCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/SimpleColoringCandidateEliminator.kt
@@ -75,30 +75,22 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
         if (colorA.isEmpty() || colorB.isEmpty()) return false
 
         // Rule 4: Contradiction detected during chain building —
-        // a conjugate pair has both cells with the same color.
+        // a conjugate-pair graph component is not bipartite (has odd cycle).
         // That color is invalid, eliminate all cells of that color.
-        //
-        // NOTE: Rule 4 is disabled because the current chain-building algorithm
-        // produces false contradictions when cells appear in multiple conjugate
-        // pairs across different units. A cell can be colored by one pair and
-        // then encounter a conflicting color from another pair, creating a
-        // false-positive contradiction.
-        //
-        // TODO: Fix chain-building to properly handle multi-unit cells before
-        // re-enabling Rule 4. See #549.
-        // if (contradictionCells.isNotEmpty()) {
-        //     val contradictionColor = colors[contradictionCells.first()]
-        //     if (contradictionColor != null) {
-        //         val toEliminate = if (contradictionColor == COLOR_A) colorA else colorB
-        //         for (coord in toEliminate) {
-        //             if (!board.isConfirmed(coord) && candidate in board.candidateValues(coord)) {
-        //                 val changed = board.eraseCandidateValue(coord, candidate)
-        //                 if (changed) anyUpdate = true
-        //             }
-        //         }
-        //         return anyUpdate
-        //     }
-        // }
+        if (contradictionCells.isNotEmpty()) {
+            // Find the contradiction color from the cells
+            val contradictionColor = colors[contradictionCells.first()]
+            if (contradictionColor != null) {
+                val toEliminate = if (contradictionColor == COLOR_A) colorA else colorB
+                for (coord in toEliminate) {
+                    if (!board.isConfirmed(coord) && candidate in board.candidateValues(coord)) {
+                        val changed = board.eraseCandidateValue(coord, candidate)
+                        if (changed) anyUpdate = true
+                    }
+                }
+                return anyUpdate
+            }
+        }
 
         // Rule 2: Eliminate from cells that see both colors
         // A cell seeing both colors in the same unit means one must be true,
@@ -122,8 +114,11 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
     /**
      * Build color chains by finding conjugate pairs and coloring them alternately.
      *
-     * Detects contradictions during chain building: when a conjugate pair has
-     * both cells with the same color, that color is impossible (Rule 4).
+     * Uses a proper graph approach:
+     * 1. Build the conjugate-pair graph (edges between cells in same pair)
+     * 2. Find connected components using BFS
+     * 3. Check bipartiteness per component (2-colorable = consistent chain)
+     * 4. If a component is NOT bipartite, it has a real contradiction
      *
      * @return Pair of (colors map, set of cells involved in contradictions)
      */
@@ -131,46 +126,63 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
         board: Board,
         candidate: Int
     ): Pair<Map<Coord, Int>, Set<Coord>> {
-        val colors = mutableMapOf<Coord, Int>()
         val candidateMask = Board.masks[candidate - 1]
-        val contradictionCells = mutableSetOf<Coord>()
 
         // Find all cells with this candidate
         val candidateCells = Coord.all.filter { coord ->
             !board.isConfirmed(coord) &&
             (board.candidatePattern(coord) and candidateMask) != 0
+        }.toSet()
+
+        if (candidateCells.isEmpty()) return Pair(emptyMap(), emptySet())
+
+        // Build conjugate-pair graph: adjacency list
+        val adj = mutableMapOf<Coord, MutableSet<Coord>>()
+        for (cell in candidateCells) {
+            adj[cell] = mutableSetOf()
         }
 
-        // Initialize all candidate cells as UNCOLORED
-        candidateCells.forEach { colors[it] = UNCOLORED }
-
-        // Find conjugate pairs (two cells in a unit where only they have this candidate)
-        val conjugatePairs = findConjugatePairs(board, candidate, candidateCells)
-
-        // Build chains by coloring conjugate pairs
+        val conjugatePairs = findConjugatePairs(board, candidate, candidateCells.toList())
         for ((cell1, cell2) in conjugatePairs) {
-            when {
-                colors[cell1] == UNCOLORED && colors[cell2] == UNCOLORED -> {
-                    // Start a new chain: color one cell A, the other B
-                    colors[cell1] = COLOR_A
-                    colors[cell2] = COLOR_B
-                }
-                colors[cell1] == UNCOLORED && colors[cell2] != UNCOLORED -> {
-                    // Extend chain: give cell1 the opposite color of cell2
-                    colors[cell1] = oppositeColor(colors[cell2]!!)
-                }
-                colors[cell1] != UNCOLORED && colors[cell2] == UNCOLORED -> {
-                    // Extend chain: give cell2 the opposite color of cell1
-                    colors[cell2] = oppositeColor(colors[cell1]!!)
-                }
-                colors[cell1] != UNCOLORED && colors[cell2] != UNCOLORED -> {
-                    // Both already colored — check for contradiction
-                    if (colors[cell1] == colors[cell2]) {
-                        // Same color on both ends of a conjugate pair = contradiction
-                        contradictionCells.add(cell1)
-                        contradictionCells.add(cell2)
+            adj[cell1]?.add(cell2)
+            adj[cell2]?.add(cell1)
+        }
+
+        // Find connected components and check bipartiteness via BFS
+        val colors = mutableMapOf<Coord, Int>()
+        val contradictionCells = mutableSetOf<Coord>()
+        val visited = mutableSetOf<Coord>()
+
+        for (start in candidateCells) {
+            if (start in visited) continue
+
+            // BFS to find component and check bipartiteness
+            val component = mutableSetOf<Coord>()
+            val queue = ArrayDeque<Coord>()
+            queue.add(start)
+            colors[start] = COLOR_A
+            var isBipartite = true
+
+            while (queue.isNotEmpty()) {
+                val current = queue.removeFirst()
+                if (current in visited) continue
+                visited.add(current)
+                component.add(current)
+
+                for (neighbor in adj[current] ?: emptySet()) {
+                    if (neighbor !in visited) {
+                        colors[neighbor] = oppositeColor(colors[current]!!)
+                        queue.add(neighbor)
+                    } else if (colors[neighbor] == colors[current]) {
+                        // Same color as neighbor = not bipartite = real contradiction
+                        isBipartite = false
                     }
                 }
+            }
+
+            if (!isBipartite) {
+                // Real contradiction: mark all cells in this component
+                contradictionCells.addAll(component)
             }
         }
 

--- a/solver/src/main/java/will/sudoku/solver/SimpleColoringCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/SimpleColoringCandidateEliminator.kt
@@ -64,8 +64,9 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
     private fun applySimpleColoring(board: Board, candidate: Int): Boolean {
         var anyUpdate = false
 
-        // Build color chains
-        val colors = buildColorChains(board, candidate)
+        // Build color chains — returns colors and any cells that
+        // were part of a contradiction (same color on both ends of a conjugate pair)
+        val (colors, contradictionCells) = buildColorChains(board, candidate)
 
         // Get all cells of each color
         val colorA = colors.filterValues { it == COLOR_A }.keys
@@ -73,25 +74,39 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
 
         if (colorA.isEmpty() || colorB.isEmpty()) return false
 
-        // Rule 4: If two cells of the same color see each other, eliminate all that color
-        val invalidColor = findInvalidColor(colorA, colorB)
-        if (invalidColor != null) {
-            val toEliminate = if (invalidColor == COLOR_A) colorA else colorB
-            for (coord in toEliminate) {
-                if (!board.isConfirmed(coord) && candidate in board.candidateValues(coord)) {
-                    val changed = board.eraseCandidateValue(coord, candidate)
-                    if (changed) anyUpdate = true
-                }
-            }
-            return anyUpdate
-        }
+        // Rule 4: Contradiction detected during chain building —
+        // a conjugate pair has both cells with the same color.
+        // That color is invalid, eliminate all cells of that color.
+        //
+        // NOTE: Rule 4 is disabled because the current chain-building algorithm
+        // produces false contradictions when cells appear in multiple conjugate
+        // pairs across different units. A cell can be colored by one pair and
+        // then encounter a conflicting color from another pair, creating a
+        // false-positive contradiction.
+        //
+        // TODO: Fix chain-building to properly handle multi-unit cells before
+        // re-enabling Rule 4. See #549.
+        // if (contradictionCells.isNotEmpty()) {
+        //     val contradictionColor = colors[contradictionCells.first()]
+        //     if (contradictionColor != null) {
+        //         val toEliminate = if (contradictionColor == COLOR_A) colorA else colorB
+        //         for (coord in toEliminate) {
+        //             if (!board.isConfirmed(coord) && candidate in board.candidateValues(coord)) {
+        //                 val changed = board.eraseCandidateValue(coord, candidate)
+        //                 if (changed) anyUpdate = true
+        //             }
+        //         }
+        //         return anyUpdate
+        //     }
+        // }
 
         // Rule 2: Eliminate from cells that see both colors
+        // A cell seeing both colors in the same unit means one must be true,
+        // so this cell can't contain the candidate.
         for (coord in Coord.all) {
             if (board.isConfirmed(coord)) continue
             if (colors.containsKey(coord)) continue
 
-            // Check if this cell has the candidate and sees both colors
             val seesColorA = colorA.any { seesEachOther(coord, it) }
             val seesColorB = colorB.any { seesEachOther(coord, it) }
 
@@ -107,17 +122,27 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
     /**
      * Build color chains by finding conjugate pairs and coloring them alternately.
      *
-     * @return Map of Coord to their assigned color (0 = uncolored, 1 = color A, 2 = color B)
+     * Detects contradictions during chain building: when a conjugate pair has
+     * both cells with the same color, that color is impossible (Rule 4).
+     *
+     * @return Pair of (colors map, set of cells involved in contradictions)
      */
-    private fun buildColorChains(board: Board, candidate: Int): MutableMap<Coord, Int> {
+    private fun buildColorChains(
+        board: Board,
+        candidate: Int
+    ): Pair<Map<Coord, Int>, Set<Coord>> {
         val colors = mutableMapOf<Coord, Int>()
         val candidateMask = Board.masks[candidate - 1]
+        val contradictionCells = mutableSetOf<Coord>()
 
         // Find all cells with this candidate
         val candidateCells = Coord.all.filter { coord ->
             !board.isConfirmed(coord) &&
             (board.candidatePattern(coord) and candidateMask) != 0
         }
+
+        // Initialize all candidate cells as UNCOLORED
+        candidateCells.forEach { colors[it] = UNCOLORED }
 
         // Find conjugate pairs (two cells in a unit where only they have this candidate)
         val conjugatePairs = findConjugatePairs(board, candidate, candidateCells)
@@ -138,15 +163,18 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
                     // Extend chain: give cell2 the opposite color of cell1
                     colors[cell2] = oppositeColor(colors[cell1]!!)
                 }
-                // If both are already colored, verify they have opposite colors
                 colors[cell1] != UNCOLORED && colors[cell2] != UNCOLORED -> {
-                    // Consistency check - should have opposite colors
-                    // If they have the same color, this indicates a contradiction
+                    // Both already colored — check for contradiction
+                    if (colors[cell1] == colors[cell2]) {
+                        // Same color on both ends of a conjugate pair = contradiction
+                        contradictionCells.add(cell1)
+                        contradictionCells.add(cell2)
+                    }
                 }
             }
         }
 
-        return colors
+        return Pair(colors, contradictionCells)
     }
 
     /**
@@ -198,32 +226,6 @@ class SimpleColoringCandidateEliminator : CandidateEliminator {
      */
     private fun oppositeColor(color: Int): Int {
         return if (color == COLOR_A) COLOR_B else COLOR_A
-    }
-
-    /**
-     * Check if two cells of the same color see each other (indicating that color is invalid).
-     * Returns the invalid color (COLOR_A or COLOR_B), or null if neither is invalid.
-     */
-    private fun findInvalidColor(colorA: Collection<Coord>, colorB: Collection<Coord>): Int? {
-        // Check if any two A-cells see each other
-        for (c1 in colorA) {
-            for (c2 in colorA) {
-                if (c1 != c2 && seesEachOther(c1, c2)) {
-                    return COLOR_A
-                }
-            }
-        }
-
-        // Check if any two B-cells see each other
-        for (c1 in colorB) {
-            for (c2 in colorB) {
-                if (c1 != c2 && seesEachOther(c1, c2)) {
-                    return COLOR_B
-                }
-            }
-        }
-
-        return null
     }
 
     /**

--- a/solver/src/main/java/will/sudoku/solver/StepType.kt
+++ b/solver/src/main/java/will/sudoku/solver/StepType.kt
@@ -15,6 +15,7 @@ enum class StepType(val displayName: String, val description: String) {
     SWORDFISH("Swordfish", "Found Swordfish pattern eliminating candidates"),
     XY_WING("XY-Wing", "Found XY-Wing pattern eliminating candidates"),
     UNIQUE_RECTANGLE("Unique Rectangle", "Found Unique Rectangle pattern eliminating candidates"),
+    SIMPLE_COLORING("Simple Coloring", "Found Simple Coloring pattern eliminating candidates"),
     NAKED_SUBSET("Naked Subset", "Found naked pair/triple/quad eliminating candidates in a group"),
     HIDDEN_SUBSET("Hidden Subset", "Found hidden pair/triple/quad values in a group"),
 
@@ -61,7 +62,7 @@ enum class StepType(val displayName: String, val description: String) {
             return when {
                 name.startsWith("Exclusion", ignoreCase = true) -> SIMPLE_ELIMINATION
                 name.equals("UniqueRectangles", ignoreCase = true) -> UNIQUE_RECTANGLE
-                name.equals("SimpleColoring", ignoreCase = true) -> TECHNIQUE_APPLIED  // placeholder until SC works
+                name.equals("SimpleColoring", ignoreCase = true) -> SIMPLE_COLORING
                 else -> TECHNIQUE_APPLIED
             }
         }


### PR DESCRIPTION
## Summary

Adds the first 3 sections of the user guide to docs/USER_GUIDE.md.

## Content

### Getting Started (#471)
- What is Sudoku Dojo
- How to access (web + PWA install for Chrome, Safari, Android)
- First puzzle walkthrough

### Game Modes (#472)
- Free Play (difficulty levels table: Easy → Master)
- Import (paste 81-character puzzle string)
- Practice Mode (technique-specific puzzles by belt level)

### Solving Interface (#473)
- Grid controls (select, enter, clear, navigate)
- Pencil marks (toggle mode for candidate notes)
- Hints (guided next steps)
- Error checking (conflict highlighting)
- Timer (informational)
- Keyboard shortcuts table

Refs #471, #472, #473