### PR TITLE
feat: add staging environment support (#562)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2,6 +2,11 @@
 # Sudoku Dojo — Deploy Smoke Test
 # Verifies the deployment is healthy after a deploy.
 # Exit code: 0 = success, 1 = failure
+#
+# Usage:
+#   Production:  ./scripts/smoke-test.sh
+#   Staging:     SUDOKU_URL=http://localhost:25322 ./scripts/smoke-test.sh
+#   Commit check: EXPECTED_COMMIT=abc1234 ./scripts/smoke-test.sh
 
 set -euo pipefail
 

--- a/scripts/sudoku-solver-staging.service
+++ b/scripts/sudoku-solver-staging.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Sudoku Dojo (Staging)
+After=network.target
+
+[Service]
+Type=simple
+User=sudoku
+WorkingDirectory=/opt/sudoku-solver-staging
+Environment=PORT=25322
+Environment=STAGING=true
+Environment=DEPLOY_COMMIT_FILE=/opt/sudoku-solver-staging/.deploy-commit
+Environment=BUILD_TIMESTAMP_FILE=/opt/sudoku-solver-staging/.build-timestamp
+ExecStart=/opt/sudoku-solver-staging/bin/web
+Restart=on-failure
+RestartSec=2s
+StartLimitIntervalSec=60s
+StartLimitBurst=5
+
+# Security hardening
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/opt/sudoku-solver-staging
+PrivateTmp=yes
+PrivateDevices=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HealthRoutes.kt
@@ -15,6 +15,7 @@ data class HealthResponse(
     val version: String,
     val timestamp: Long = System.currentTimeMillis(),
     val gitCommit: String? = null,
+    val environment: String = if (System.getenv("STAGING") == "true") "staging" else "production",
     val uptime: UptimeInfo? = null,
     val jvm: JvmInfo? = null,
     val system: SystemInfo? = null


### PR DESCRIPTION
Refs #562

## Changes
- Add `environment` field to `/api/v1/health` response — returns `"staging"` when `STAGING=true` env var is set, `"production"` otherwise
- Create `scripts/sudoku-solver-staging.service` — systemd service template for staging deployment on port 25322 with security hardening
- Document staging smoke test usage in `scripts/smoke-test.sh` (`SUDOKU_URL=http://localhost:25322`)

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend lint clean (`npm run lint:ci`)
- [x] Frontend builds (`npm run build`)
- [x] Backend distribution builds (`./gradlew :web:installDist`)

## Self-Review
- [x] PR description matches actual diff (3 files changed, 34 insertions)
- [x] No unrelated/lint-only/stray changes slipped in
- [x] Health endpoint behavior unchanged in production mode (default is "production")
- [x] Service file uses proper security hardening matching production service patterns