### PR TITLE
docs: remove remaining Render deployment references (#565)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ GitHub Actions:
 - **Detekt** — Kotlin static analysis on push to `master` + weekly
 - **JMH** — Manual dispatch only
 
-JDK 21 required. Auto-deploys to Render on merge to `master`.
+JDK 21 required. Deployed via `scripts/deploy.sh` to systemd service.
 
 ## Architecture
 
@@ -148,7 +148,7 @@ Tests in `kotlin/src/test/`:
 
 ## Branch Strategy
 
-- **master** — Stable, auto-deploys to Render
+- **master** — Stable, deployed via `scripts/deploy.sh`
 - Branch protection: CI required, reviews required, linear history, admin enforcement
 
 ## Adding a New Feature

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ docker run -p 10000:10000 sudoku-dojo
 ## CI/CD
 
 - **GitHub Actions** — Java CI (tests), Detekt (static analysis), CodeQL (security), JMH (manual benchmarks)
-- **Auto-deploy** to Render on merge to `master`
+- **Deploy** via `scripts/deploy.sh` with atomic swap and smoke test
 - **Branch protection** — CI required, reviews required, linear history, admin enforcement
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ After 304+ PRs merged and the full feature set shipped, focus is on quality and 
 ### Stack
 - **Backend:** Kotlin 2.1 (Ktor) + JUnit 5
 - **Frontend:** Vue 3 (Composition API) + Vite 5 + Vitest
-- **Infrastructure:** Render.com, GitHub Actions CI
+- **Infrastructure:** Systemd service on VPS, GitHub Actions CI
 - **Tests:** 389 tests, 0 failures
 
 ### Architecture

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -66,7 +66,6 @@
 **Phase 5: Build Integration**
 - [x] Update Ktor to serve Vue build output
 - [x] Test end-to-end locally
-- [ ] Test on Render preview
 
 ### Workflow
 - [x] 📦 Commit Phase 1-3

--- a/docs/agents/skills/sudoku-coder.md
+++ b/docs/agents/skills/sudoku-coder.md
@@ -14,7 +14,7 @@ Implementation agent for sudoku-solver. Follows plans and standard git flow.
 - **Stack:** Kotlin 2.1 (Ktor) + Vue 3 + Vite
 - **JDK:** 21
 - **CI:** GitHub Actions (tests on push/PR)
-- **Deploy:** Auto-deploys to Render on merge to master
+- **Deploy:** Deploys via `scripts/deploy.sh` to systemd service
 
 ## Context Loading (Before Every Task)
 

--- a/docs/agents/skills/sudoku-reviewer.md
+++ b/docs/agents/skills/sudoku-reviewer.md
@@ -205,7 +205,6 @@ After merge, confirm deployment:
 
 ```bash
 # Trigger local deploy if needed
-# (Remote auto-deploys to Render)
 ```
 
 ## Rules


### PR DESCRIPTION
Refs #565

## Changes
Remove all remaining Render deployment references across 6 files:

| File | Change |
|---|---|
| `CLAUDE.md` | Update deploy info from Render to systemd/`deploy.sh` (2 lines) |
| `README.md` | Update CI/CD section to reflect `deploy.sh` |
| `ROADMAP.md` | Replace `Render.com` with `Systemd service on VPS` |
| `docs/TASKS.md` | Remove `Test on Render preview` task item |
| `docs/agents/skills/sudoku-coder.md` | Update deploy description |
| `docs/agents/skills/sudoku-reviewer.md` | Remove Render deploy comment |

## Verification
```bash
$ grep -rn -i "render\.com\|render deploy\|auto-deploy.*render\|deploys to render\|render preview\|onrender" . --include="*.md" | grep -v node_modules
# (no results)
```

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend lint clean (`npm run lint:ci`)
- [x] Frontend builds (`npm run build`)