### PR TITLE
feat: add 7 advanced eliminators to defaultEliminators()

### DIFF
--- a/packages/solver/src/Solver.ts
+++ b/packages/solver/src/Solver.ts
@@ -3,8 +3,14 @@ import type { CandidateEliminator } from './Eliminators'
 import {
     SimpleCandidateEliminator,
     GroupCandidateEliminator,
+    HiddenSubsetCandidateEliminator,
     ExclusionCandidateEliminator,
-    DeathBlossomCandidateEliminator,
+    PointingCandidateEliminator,
+    ClaimingCandidateEliminator,
+    FishCandidateEliminator,
+    SkyscraperCandidateEliminator,
+    TwoStringKiteCandidateEliminator,
+    WWingCandidateEliminator,
 } from './Eliminators'
 import { Coord } from './Coord'
 
@@ -59,13 +65,25 @@ export class SolverConfig {
     }
 }
 
-/** Default eliminators: the 3 core techniques. */
+/**
+ * Default eliminators: all 10 production-ready TS eliminators.
+ *
+ * Excluded:
+ *   EmptyRectangle — makes incorrect eliminations (known bug, breaks solver)
+ *   DeathBlossom  — too slow for default set (combinatorial explosion)
+ */
 function defaultEliminators(): readonly CandidateEliminator[] {
     return [
         new SimpleCandidateEliminator(),
         new GroupCandidateEliminator(),
+        new HiddenSubsetCandidateEliminator(),
         new ExclusionCandidateEliminator(9),
-        new DeathBlossomCandidateEliminator(),
+        new PointingCandidateEliminator(),
+        new ClaimingCandidateEliminator(),
+        new FishCandidateEliminator(),
+        new SkyscraperCandidateEliminator(),
+        new TwoStringKiteCandidateEliminator(),
+        new WWingCandidateEliminator(),
     ]
 }
 


### PR DESCRIPTION
## Summary
Adds 7 already-implemented TS eliminators to the default solver configuration, going from 4 to 10 eliminators.

## Changes
- **Solver.ts**: Updated `defaultEliminators()` to include:
  - HiddenSubsetCandidateEliminator
  - PointingCandidateEliminator
  - ClaimingCandidateEliminator
  - FishCandidateEliminator
  - SkyscraperCandidateEliminator
  - TwoStringKiteCandidateEliminator
  - WWingCandidateEliminator
- Removed DeathBlossom from defaults (too slow, ~150 LOC combinatorial algorithm)

## Excluded
| Eliminator | Reason |
|---|---|
| EmptyRectangleCandidateEliminator | Known bug — makes incorrect eliminations, breaks solver |
| DeathBlossomCandidateEliminator | Too slow — combinatorial explosion in solver loop |

## Verification
- **213 tests pass** (16 test files, 0 failures)
- **tsc --noEmit** — 0 errors
- g3, g4, multi-solution parity tests all pass

Refs #577