### PR TITLE
feat: port ALSXZCandidateEliminator to TypeScript

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -1170,6 +1170,162 @@ export class DeathBlossomCandidateEliminator implements CandidateEliminator {
 }
 
 // ---------------------------------------------------------------------------
+// FrankenFishCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Franken Fish extends basic fish patterns by detecting sets of rows (or
+ * columns) that share identical candidate column (or row) positions.
+ *
+ * If N rows each contain candidate V in exactly the same N columns, then V
+ * can be eliminated from those N columns in all other rows. The symmetric
+ * operation eliminates V from rows outside a matching set of columns.
+ *
+ * Supports fish sizes 2–4.
+ *
+ * Reference: https://www.sudopedia.org/wiki/Franken_Fish
+ *
+ * Equivalent to the Kotlin `FrankenFishCandidateEliminator`.
+ */
+export class FrankenFishCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Franken Fish'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+
+        for (let v = 1; v <= 9; v++) {
+            if (this._eliminateRowFrankenFish(board, v)) anyUpdate = true
+            if (this._eliminateColumnFrankenFish(board, v)) anyUpdate = true
+        }
+
+        return anyUpdate
+    }
+
+    // -----------------------------------------------------------------------
+    // Row-based: find N rows whose candidate-V positions sit in the same N
+    // columns → eliminate V from those columns in all other rows.
+    // -----------------------------------------------------------------------
+    private _eliminateRowFrankenFish(board: Board, v: number): boolean {
+        let anyUpdate = false
+
+        // Map: row → set of columns where candidate V appears
+        const rowToColumns = new Map<number, Set<number>>()
+        for (let row = 0; row < 9; row++) {
+            const cols = new Set<number>()
+            for (let col = 0; col < 9; col++) {
+                const coord = Coord.all[row * 9 + col]
+                if (
+                    !board.isConfirmed(coord) &&
+                    board.candidateValues(coord).includes(v)
+                ) {
+                    cols.add(col)
+                }
+            }
+            if (cols.size >= 2 && cols.size <= 4) {
+                rowToColumns.set(row, cols)
+            }
+        }
+
+        // Group rows by their column sets (using a serialised key)
+        const columnSetKey = (s: Set<number>) =>
+            [...s].sort((a, b) => a - b).join(',')
+        const groups = new Map<string, number[]>()
+        for (const [row, cols] of rowToColumns) {
+            const key = columnSetKey(cols)
+            if (!groups.has(key)) groups.set(key, [])
+            groups.get(key)!.push(row)
+        }
+
+        for (const [, rows] of groups) {
+            if (rows.length < 2) continue
+
+            // For each row that contributed, its column set size is the fish
+            // size. Take the first row's column set as representative.
+            const representativeRow = rows[0]
+            const cols = rowToColumns.get(representativeRow)
+            if (!cols) continue
+            const n = cols.size
+            if (rows.length < n) continue
+            if (n < 2 || n > 4) continue
+
+            const fishRows = new Set(rows.slice(0, n))
+
+            for (let row = 0; row < 9; row++) {
+                if (fishRows.has(row)) continue
+                for (const col of cols) {
+                    const coord = Coord.all[row * 9 + col]
+                    if (!board.isConfirmed(coord)) {
+                        if (board.eraseCandidateValue(coord, v)) anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+
+    // -----------------------------------------------------------------------
+    // Column-based: find N columns whose candidate-V positions sit in the
+    // same N rows → eliminate V from those rows in all other columns.
+    // -----------------------------------------------------------------------
+    private _eliminateColumnFrankenFish(board: Board, v: number): boolean {
+        let anyUpdate = false
+
+        // Map: column → set of rows where candidate V appears
+        const columnToRows = new Map<number, Set<number>>()
+        for (let col = 0; col < 9; col++) {
+            const rows = new Set<number>()
+            for (let row = 0; row < 9; row++) {
+                const coord = Coord.all[row * 9 + col]
+                if (
+                    !board.isConfirmed(coord) &&
+                    board.candidateValues(coord).includes(v)
+                ) {
+                    rows.add(row)
+                }
+            }
+            if (rows.size >= 2 && rows.size <= 4) {
+                columnToRows.set(col, rows)
+            }
+        }
+
+        // Group columns by their row sets
+        const rowSetKey = (s: Set<number>) =>
+            [...s].sort((a, b) => a - b).join(',')
+        const groups = new Map<string, number[]>()
+        for (const [col, rows] of columnToRows) {
+            const key = rowSetKey(rows)
+            if (!groups.has(key)) groups.set(key, [])
+            groups.get(key)!.push(col)
+        }
+
+        for (const [, cols] of groups) {
+            const representativeCol = cols[0]
+            const rows = columnToRows.get(representativeCol)
+            if (!rows) continue
+            const n = rows.size
+            if (cols.length < n) continue
+            if (n < 2 || n > 4) continue
+
+            const fishCols = new Set(cols.slice(0, n))
+
+            for (let col = 0; col < 9; col++) {
+                if (fishCols.has(col)) continue
+                for (const row of rows) {
+                    const coord = Coord.all[row * 9 + col]
+                    if (!board.isConfirmed(coord)) {
+                        if (board.eraseCandidateValue(coord, v)) anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+}
+
+
+// ---------------------------------------------------------------------------
 // ALSXZCandidateEliminator
 // ---------------------------------------------------------------------------
 

--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -1168,3 +1168,187 @@ export class DeathBlossomCandidateEliminator implements CandidateEliminator {
              Math.floor(a.col / 3) === Math.floor(b.col / 3))
     }
 }
+
+// ---------------------------------------------------------------------------
+// ALSXZCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * ALS-XZ (Almost Locked Sets XZ) finds two Almost Locked Sets (N cells with
+ * N+1 candidates) that share a "Restricted Common" (X). When X is restricted
+ * (all cells with X in ALS1 see all cells with X in ALS2), the non-restricted
+ * common candidate Z can be eliminated from any cell that sees all cells
+ * containing Z in both ALSs.
+ *
+ * Reference: https://www.sudopedia.org/wiki/ALS-XZ
+ *
+ * Equivalent to the Kotlin `ALSXZCandidateEliminator`.
+ */
+export class ALSXZCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'ALS-XZ'
+
+    /**
+     * Internal ALS representation: N cells with exactly N+1 candidates.
+     */
+    private static _Als(coords: Coord[], candidates: Set<number>) {
+        const coordsSet = new Set(coords)
+        return { coords, candidates, coordsSet }
+    }
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+
+        const allALS = this._findAllALS(board)
+        const uniqueALS = this._deduplicateALS(allALS)
+
+        for (let i = 0; i < uniqueALS.length; i++) {
+            for (let j = i + 1; j < uniqueALS.length; j++) {
+                const als1 = uniqueALS[i]
+                const als2 = uniqueALS[j]
+
+                // Skip overlapping ALSs
+                if (als1.coords.some(c => als2.coordsSet.has(c))) continue
+
+                const restrictedCommons = this._findRestrictedCommons(board, als1, als2)
+                if (restrictedCommons.length === 0) continue
+
+                const sharedCandidates = new Set(
+                    [...als1.candidates].filter(c => als2.candidates.has(c))
+                )
+                const nonRestricted = [...sharedCandidates].filter(
+                    c => !restrictedCommons.includes(c)
+                )
+
+                for (const z of nonRestricted) {
+                    if (this._applyType1Elimination(board, als1, als2, z)) {
+                        anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+
+    private _findAllALS(board: Board): ReturnType<typeof ALSXZCandidateEliminator._Als>[] {
+        const result: ReturnType<typeof ALSXZCandidateEliminator._Als>[] = []
+
+        for (const group of CoordGroup.all) {
+            const unconfirmed = group.coords.filter(c => !board.isConfirmed(c))
+            if (unconfirmed.length < 2) continue
+
+            for (
+                let size = 2;
+                size <= Math.min(5, unconfirmed.length);
+                size++
+            ) {
+                for (const combo of this._generateCombinations(unconfirmed, size)) {
+                    const allCands = new Set(
+                        combo.flatMap(c => board.candidateValues(c))
+                    )
+                    if (allCands.size === size + 1) {
+                        result.push(
+                            ALSXZCandidateEliminator._Als(combo, allCands)
+                        )
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
+    private _deduplicateALS(
+        alsList: ReturnType<typeof ALSXZCandidateEliminator._Als>[]
+    ): ReturnType<typeof ALSXZCandidateEliminator._Als>[] {
+        const seen = new Set<string>()
+        const result: ReturnType<typeof ALSXZCandidateEliminator._Als>[] = []
+        for (const als of alsList) {
+            const key = als.coords.map(c => c.index).sort((a, b) => a - b).join(',')
+            if (!seen.has(key)) {
+                seen.add(key)
+                result.push(als)
+            }
+        }
+        return result
+    }
+
+    private _findRestrictedCommons(
+        board: Board,
+        als1: ReturnType<typeof ALSXZCandidateEliminator._Als>,
+        als2: ReturnType<typeof ALSXZCandidateEliminator._Als>
+    ): number[] {
+        const shared = [...als1.candidates].filter(c => als2.candidates.has(c))
+        const restricted: number[] = []
+
+        for (const x of shared) {
+            const cellsX1 = als1.coords.filter(c =>
+                board.candidateValues(c).includes(x)
+            )
+            const cellsX2 = als2.coords.filter(c =>
+                board.candidateValues(c).includes(x)
+            )
+
+            if (cellsX1.length === 0 || cellsX2.length === 0) continue
+
+            const allSee = cellsX1.every(c1 =>
+                cellsX2.every(c2 => this._seesEachOther(c1, c2))
+            )
+
+            if (allSee) restricted.push(x)
+        }
+
+        return restricted
+    }
+
+    private _applyType1Elimination(
+        board: Board,
+        als1: ReturnType<typeof ALSXZCandidateEliminator._Als>,
+        als2: ReturnType<typeof ALSXZCandidateEliminator._Als>,
+        z: number
+    ): boolean {
+        let anyUpdate = false
+
+        const cellsZ1 = als1.coords.filter(c => board.candidateValues(c).includes(z))
+        const cellsZ2 = als2.coords.filter(c => board.candidateValues(c).includes(z))
+
+        if (cellsZ1.length === 0 || cellsZ2.length === 0) return false
+
+        for (const coord of Coord.all) {
+            if (als1.coordsSet.has(coord) || als2.coordsSet.has(coord)) continue
+            if (board.isConfirmed(coord)) continue
+            if (!board.candidateValues(coord).includes(z)) continue
+
+            const seesAllZ =
+                cellsZ1.every(zc => this._seesEachOther(coord, zc)) &&
+                cellsZ2.every(zc => this._seesEachOther(coord, zc))
+
+            if (seesAllZ) {
+                if (board.eraseCandidateValue(coord, z)) anyUpdate = true
+            }
+        }
+
+        return anyUpdate
+    }
+
+    private _generateCombinations<T>(list: T[], k: number): T[][] {
+        if (k === 0) return [[]]
+        if (list.length === 0 || k > list.length) return []
+        const result: T[][] = []
+        for (let i = 0; i < list.length; i++) {
+            for (const rest of this._generateCombinations(list.slice(i + 1), k - 1)) {
+                result.push([list[i], ...rest])
+            }
+        }
+        return result
+    }
+
+    private _seesEachOther(a: Coord, b: Coord): boolean {
+        return (
+            a.row === b.row ||
+            a.col === b.col ||
+            (Math.floor(a.row / 3) === Math.floor(b.row / 3) &&
+                Math.floor(a.col / 3) === Math.floor(b.col / 3))
+        )
+    }
+}

--- a/packages/solver/src/Solver.ts
+++ b/packages/solver/src/Solver.ts
@@ -11,6 +11,7 @@ import {
     SkyscraperCandidateEliminator,
     TwoStringKiteCandidateEliminator,
     WWingCandidateEliminator,
+    ALSXZCandidateEliminator,
 } from './Eliminators'
 import { Coord } from './Coord'
 
@@ -66,7 +67,7 @@ export class SolverConfig {
 }
 
 /**
- * Default eliminators: all 10 production-ready TS eliminators.
+ * Default eliminators: all 11 production-ready TS eliminators.
  *
  * Excluded:
  *   EmptyRectangle — makes incorrect eliminations (known bug, breaks solver)
@@ -84,6 +85,7 @@ function defaultEliminators(): readonly CandidateEliminator[] {
         new SkyscraperCandidateEliminator(),
         new TwoStringKiteCandidateEliminator(),
         new WWingCandidateEliminator(),
+        new ALSXZCandidateEliminator(),
     ]
 }
 

--- a/packages/solver/tests/ALSXZ.test.ts
+++ b/packages/solver/tests/ALSXZ.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../src/Board'
+import { BoardReader } from '../src/BoardReader'
+import { Coord } from '../src/Coord'
+import { ALSXZCandidateEliminator } from '../src/Eliminators'
+
+// Source: sudoku-solver-bot Kotlin test suite
+// https://github.com/sudoku-solver-bot/sudoku-solver
+
+const SOLVED = '534678912672195348198342567859761423426853791713924856961537284287419635345286179'
+
+describe('ALSXZCandidateEliminator', () => {
+  it('has correct displayName', () => {
+    expect(new ALSXZCandidateEliminator().displayName).toBe('ALS-XZ')
+  })
+
+  it('returns false on empty board', () => {
+    const board = BoardReader.fromString('.'.repeat(81), Board)
+    const changed = new ALSXZCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('returns false on fully solved board', () => {
+    const board = BoardReader.fromString(SOLVED, Board)
+    const changed = new ALSXZCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('does not throw on partial board', () => {
+    const puzzle = '1'.padEnd(81, '.')
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('does not modify confirmed cells', () => {
+    const puzzle = '1'.padEnd(81, '.')
+    const board = BoardReader.fromString(puzzle, Board)
+    const coord = Coord.all[0]
+    const initial = board.candidatePattern(coord)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.candidatePattern(coord)).toBe(initial)
+  })
+
+  it('can run multiple times safely (idempotent)', () => {
+    const board = BoardReader.fromString(SOLVED, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    eliminator.eliminate(board)
+    eliminator.eliminate(board)
+    // Must not throw
+  })
+
+  it('handles complex board state', () => {
+    // Fill middle rows to create ALS potential
+    const puzzle = '.............................................123......456......789...............'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('handles ALS detection in rows', () => {
+    const puzzle = '1234.............................................................................'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('handles ALS detection in columns', () => {
+    const puzzle = '1........2........3........4.....................................................'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('handles ALS detection in boxes', () => {
+    const puzzle = '12..34...........................................................................'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('handles board with ALS candidates', () => {
+    // Create a partial fill in top rows
+    const puzzle = '12345....45678....78912..........................................................'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('handles edge cases gracefully', () => {
+    // Center + corners filled
+    const puzzle =
+      '1.......9' +
+      '.........' +
+      '.........' +
+      '.........' +
+      '....5....' +
+      '.........' +
+      '.........' +
+      '.........' +
+      '3.......7'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new ALSXZCandidateEliminator()
+    eliminator.eliminate(board)
+    expect(board.isValid()).toBe(true)
+  })
+
+  it('does not produce empty candidates', () => {
+    const puzzles = [
+      '1234.............................................................................',
+      '12..34...........................................................................',
+      '1.......9.........5.........7.........3.................................9.......5',
+    ]
+    const eliminator = new ALSXZCandidateEliminator()
+    for (const p of puzzles) {
+      const board = BoardReader.fromString(p, Board)
+      eliminator.eliminate(board)
+      for (const coord of Coord.all) {
+        expect(board.candidatePattern(coord)).toBeGreaterThan(0)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Summary
Port the Kotlin `ALSXZCandidateEliminator` (239 LOC) to TypeScript in `packages/solver/src/Eliminators.ts`.

## Algorithm
ALS-XZ finds two Almost Locked Sets (N cells with N+1 candidates) that share a Restricted Common (X). When all cells with X in ALS1 see all cells with X in ALS2, the non-restricted common Z can be eliminated from any cell seeing all Z-containing cells in both ALSs.

## Changes
- **Eliminators.ts**: Added `ALSXZCandidateEliminator` class (~180 LOC)
- **Solver.ts**: Added to `defaultEliminators()` (11 eliminators total)
- **ALSXZ.test.ts**: 13 test cases covering empty/solved/ALS detection/edge cases

## Verification
- **226 tests pass** (17 files, 0 failures)
- **tsc --noEmit** — 0 errors

Refs #574