### PR TITLE
feat: create shared multi-unit fish pattern helper

### DIFF
--- a/packages/solver/src/FishHelpers.ts
+++ b/packages/solver/src/FishHelpers.ts
@@ -1,0 +1,117 @@
+import type { Board } from './Board'
+import { Coord } from './Coord'
+
+// ---------------------------------------------------------------------------
+// House — a row, column, or box (9-cell unit)
+// ---------------------------------------------------------------------------
+
+/** Represents a house: a row, column, or 3×3 box. */
+export type House =
+    | { kind: 'row'; index: number }
+    | { kind: 'col'; index: number }
+    | { kind: 'box'; index: number }
+
+/** All 27 houses (9 rows + 9 columns + 9 boxes). */
+export const allHouses: readonly House[] = (() => {
+    const result: House[] = []
+    for (let i = 0; i < 9; i++) {
+        result.push({ kind: 'row', index: i })
+        result.push({ kind: 'col', index: i })
+        result.push({ kind: 'box', index: i })
+    }
+    return result
+})()
+
+/** Check whether a coordinate belongs to a house. */
+export function houseContains(h: House, coord: Coord): boolean {
+    switch (h.kind) {
+        case 'row':
+            return coord.row === h.index
+        case 'col':
+            return coord.col === h.index
+        case 'box':
+            return (
+                Math.floor(coord.row / 3) === Math.floor(h.index / 3) &&
+                Math.floor(coord.col / 3) === h.index % 3
+            )
+    }
+}
+
+/**
+ * Return a stable string key for a house.
+ * Example: "row:0", "col:3", "box:8".
+ */
+export function houseKey(h: House): string {
+    return `${h.kind}:${h.index}`
+}
+
+// ---------------------------------------------------------------------------
+// Candidate position helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find all coordinates where `value` is a candidate (not yet confirmed).
+ * Returns the full Coord objects for ease of use.
+ */
+export function findCandidatePositions(board: Board, value: number): Coord[] {
+    const result: Coord[] = []
+    for (const coord of Coord.all) {
+        if (!board.isConfirmed(coord) && board.candidateValues(coord).includes(value)) {
+            result.push(coord)
+        }
+    }
+    return result
+}
+
+/**
+ * Find all houses that contain at least `minCount` positions among the
+ * given coordinate list.
+ */
+export function findHousesWithCandidates(
+    positions: readonly Coord[],
+    minCount: number,
+): House[] {
+    return allHouses.filter((house) => {
+        let count = 0
+        for (const coord of positions) {
+            if (houseContains(house, coord)) count++
+            if (count >= minCount) return true
+        }
+        return false
+    })
+}
+
+/**
+ * Build a map from house key to the list of positions within that house.
+ */
+export function buildHousePositionMap(
+    positions: readonly Coord[],
+): Map<string, Coord[]> {
+    const map = new Map<string, Coord[]>()
+    for (const house of allHouses) {
+        const inside = positions.filter((c) => houseContains(house, c))
+        if (inside.length > 0) {
+            map.set(houseKey(house), inside)
+        }
+    }
+    return map
+}
+
+// ---------------------------------------------------------------------------
+// Combinations — shared across fish eliminators
+// ---------------------------------------------------------------------------
+
+/** Generate all k-element combinations from `list`. */
+export function generateCombinations<T>(list: readonly T[], k: number): T[][] {
+    if (k === 0) return [[]]
+    if (k > list.length) return []
+    if (k === list.length) return [[...list]]
+
+    const result: T[][] = []
+    for (let i = 0; i < list.length; i++) {
+        for (const rest of generateCombinations(list.slice(i + 1), k - 1)) {
+            result.push([list[i], ...rest])
+        }
+    }
+    return result
+}

--- a/packages/solver/tests/FishHelpers.test.ts
+++ b/packages/solver/tests/FishHelpers.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../src/Board'
+import { BoardReader } from '../src/BoardReader'
+import { Coord } from '../src/Coord'
+import {
+    allHouses,
+    houseContains,
+    houseKey,
+    findCandidatePositions,
+    findHousesWithCandidates,
+    buildHousePositionMap,
+    generateCombinations,
+} from '../src/FishHelpers'
+
+describe('House', () => {
+    it('allHouses contains exactly 27 houses', () => {
+        expect(allHouses).toHaveLength(27)
+        expect(allHouses.filter((h) => h.kind === 'row')).toHaveLength(9)
+        expect(allHouses.filter((h) => h.kind === 'col')).toHaveLength(9)
+        expect(allHouses.filter((h) => h.kind === 'box')).toHaveLength(9)
+    })
+
+    it('houseContains row', () => {
+        const h = { kind: 'row' as const, index: 3 }
+        expect(houseContains(h, Coord.all[3 * 9 + 4])).toBe(true) // row 3, col 4
+        expect(houseContains(h, Coord.all[2 * 9 + 4])).toBe(false) // row 2, col 4
+    })
+
+    it('houseContains col', () => {
+        const h = { kind: 'col' as const, index: 5 }
+        expect(houseContains(h, Coord.all[2 * 9 + 5])).toBe(true) // row 2, col 5
+        expect(houseContains(h, Coord.all[2 * 9 + 4])).toBe(false) // row 2, col 4
+    })
+
+    it('houseContains box', () => {
+        const h = { kind: 'box' as const, index: 0 } // top-left box
+        expect(houseContains(h, Coord.all[0])).toBe(true)
+        expect(houseContains(h, Coord.all[1])).toBe(true)
+        expect(houseContains(h, Coord.all[9])).toBe(true)
+        expect(houseContains(h, Coord.all[10])).toBe(true)
+        expect(houseContains(h, Coord.all[3 * 9])).toBe(false) // row 3, col 0 → box 3
+    })
+
+    it('houseKey is stable', () => {
+        expect(houseKey({ kind: 'row', index: 0 })).toBe('row:0')
+        expect(houseKey({ kind: 'col', index: 3 })).toBe('col:3')
+        expect(houseKey({ kind: 'box', index: 8 })).toBe('box:8')
+    })
+})
+
+describe('findCandidatePositions', () => {
+    it('returns empty for solved board', () => {
+        const board = BoardReader.fromString(
+            '534678912672195348198342567859761423426853791713924856961537284287419635345286179',
+            Board,
+        )
+        for (let v = 1; v <= 9; v++) {
+            expect(findCandidatePositions(board, v)).toHaveLength(0)
+        }
+    })
+
+    it('finds positions on empty board', () => {
+        const board = BoardReader.fromString('.'.repeat(81), Board)
+        for (let v = 1; v <= 9; v++) {
+            expect(findCandidatePositions(board, v)).toHaveLength(81) // all open cells
+        }
+    })
+
+    it('finds correct positions on partial board', () => {
+        // 4 placed values, 77 empty cells
+        const puzzle = '1234.............................................................................'
+        const board = BoardReader.fromString(puzzle, Board)
+        // Without basic elimination, all 1-9 are candidates in all 77 empty cells
+        expect(findCandidatePositions(board, 1)).toHaveLength(77)
+        expect(findCandidatePositions(board, 5)).toHaveLength(77)
+    })
+})
+
+describe('findHousesWithCandidates', () => {
+    it('returns houses with at least minCount positions', () => {
+        const board = BoardReader.fromString('.'.repeat(81), Board)
+        const positions = findCandidatePositions(board, 1)
+        // All 27 houses have 9 positions each on empty board
+        const houses = findHousesWithCandidates(positions, 2)
+        expect(houses).toHaveLength(27)
+    })
+
+    it('filters houses below minCount threshold', () => {
+        const board = BoardReader.fromString('.'.repeat(81), Board)
+        const positions = findCandidatePositions(board, 1)
+        const houses = findHousesWithCandidates(positions, 10) // impossible threshold
+        expect(houses).toHaveLength(0)
+    })
+
+    it('works with sparse positions', () => {
+        // Only row 0 has candidate 1 at (0,0) and (0,1)
+        const puzzle =
+            '.........' +
+            '1.1......' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........'
+        const board = BoardReader.fromString(puzzle, Board)
+        const positions = findCandidatePositions(board, 1)
+        const houses = findHousesWithCandidates(positions, 2)
+        // Row 1 has 2 positions with 1
+        expect(houses.some((h) => h.kind === 'row' && h.index === 1)).toBe(true)
+    })
+})
+
+describe('buildHousePositionMap', () => {
+    it('maps houses to their positions', () => {
+        const board = BoardReader.fromString('.'.repeat(81), Board)
+        const positions = findCandidatePositions(board, 1)
+        const map = buildHousePositionMap(positions)
+        // Row 0 appears in map
+        expect(map.has('row:0')).toBe(true)
+        expect(map.get('row:0')!).toHaveLength(9)
+        expect(map.has('col:0')).toBe(true)
+        expect(map.get('col:0')!).toHaveLength(9)
+    })
+})
+
+describe('generateCombinations', () => {
+    it('generates correct combinations for k=0', () => {
+        expect(generateCombinations([1, 2, 3], 0)).toEqual([[]])
+    })
+
+    it('generates correct combinations for k=1', () => {
+        expect(generateCombinations([1, 2, 3], 1)).toEqual([[1], [2], [3]])
+    })
+
+    it('generates correct combinations for k=2', () => {
+        expect(generateCombinations([1, 2, 3], 2)).toEqual([
+            [1, 2],
+            [1, 3],
+            [2, 3],
+        ])
+    })
+
+    it('generates correct combinations for k=n', () => {
+        expect(generateCombinations([1, 2, 3], 3)).toEqual([[1, 2, 3]])
+    })
+
+    it('returns empty when k > n', () => {
+        expect(generateCombinations([1, 2], 3)).toEqual([])
+    })
+
+    it('handles empty input', () => {
+        expect(generateCombinations([], 0)).toEqual([[]])
+        expect(generateCombinations([], 1)).toEqual([])
+    })
+})


### PR DESCRIPTION
## Summary
Create `FishHelpers.ts` with shared abstractions for FrankenFish (#572) and MutantFish (#573) eliminators.

## Exports
| Export | Description |
|---|---|
| `House` type | Row, Col, Box discriminated union |
| `allHouses` | All 27 houses (9 rows + 9 cols + 9 boxes) |
| `houseContains` | Check if a coordinate belongs to a house |
| `houseKey` | Stable string key e.g. "row:0", "col:3", "box:8" |
| `findCandidatePositions` | Find all coords with a given candidate value |
| `findHousesWithCandidates` | Find houses with ≥N candidate positions |
| `buildHousePositionMap` | Map houses to their candidate positions |
| `generateCombinations` | Generate k-element combinations from a list |

## Verification
- **231 tests pass** (17 files, 0 failures)
- **tsc --noEmit** — 0 errors
- 18 new test cases for FishHelpers

Refs #581
Unblocks #572, #573