### PR TITLE
feat: port FrankenFishCandidateEliminator to TypeScript

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -1168,3 +1168,158 @@ export class DeathBlossomCandidateEliminator implements CandidateEliminator {
              Math.floor(a.col / 3) === Math.floor(b.col / 3))
     }
 }
+
+// ---------------------------------------------------------------------------
+// FrankenFishCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Franken Fish extends basic fish patterns by detecting sets of rows (or
+ * columns) that share identical candidate column (or row) positions.
+ *
+ * If N rows each contain candidate V in exactly the same N columns, then V
+ * can be eliminated from those N columns in all other rows. The symmetric
+ * operation eliminates V from rows outside a matching set of columns.
+ *
+ * Supports fish sizes 2–4.
+ *
+ * Reference: https://www.sudopedia.org/wiki/Franken_Fish
+ *
+ * Equivalent to the Kotlin `FrankenFishCandidateEliminator`.
+ */
+export class FrankenFishCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Franken Fish'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+
+        for (let v = 1; v <= 9; v++) {
+            if (this._eliminateRowFrankenFish(board, v)) anyUpdate = true
+            if (this._eliminateColumnFrankenFish(board, v)) anyUpdate = true
+        }
+
+        return anyUpdate
+    }
+
+    // -----------------------------------------------------------------------
+    // Row-based: find N rows whose candidate-V positions sit in the same N
+    // columns → eliminate V from those columns in all other rows.
+    // -----------------------------------------------------------------------
+    private _eliminateRowFrankenFish(board: Board, v: number): boolean {
+        let anyUpdate = false
+
+        // Map: row → set of columns where candidate V appears
+        const rowToColumns = new Map<number, Set<number>>()
+        for (let row = 0; row < 9; row++) {
+            const cols = new Set<number>()
+            for (let col = 0; col < 9; col++) {
+                const coord = Coord.all[row * 9 + col]
+                if (
+                    !board.isConfirmed(coord) &&
+                    board.candidateValues(coord).includes(v)
+                ) {
+                    cols.add(col)
+                }
+            }
+            if (cols.size >= 2 && cols.size <= 4) {
+                rowToColumns.set(row, cols)
+            }
+        }
+
+        // Group rows by their column sets (using a serialised key)
+        const columnSetKey = (s: Set<number>) =>
+            [...s].sort((a, b) => a - b).join(',')
+        const groups = new Map<string, number[]>()
+        for (const [row, cols] of rowToColumns) {
+            const key = columnSetKey(cols)
+            if (!groups.has(key)) groups.set(key, [])
+            groups.get(key)!.push(row)
+        }
+
+        for (const [, rows] of groups) {
+            if (rows.length < 2) continue
+
+            // For each row that contributed, its column set size is the fish
+            // size. Take the first row's column set as representative.
+            const representativeRow = rows[0]
+            const cols = rowToColumns.get(representativeRow)
+            if (!cols) continue
+            const n = cols.size
+            if (rows.length < n) continue
+            if (n < 2 || n > 4) continue
+
+            const fishRows = new Set(rows.slice(0, n))
+
+            for (let row = 0; row < 9; row++) {
+                if (fishRows.has(row)) continue
+                for (const col of cols) {
+                    const coord = Coord.all[row * 9 + col]
+                    if (!board.isConfirmed(coord)) {
+                        if (board.eraseCandidateValue(coord, v)) anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+
+    // -----------------------------------------------------------------------
+    // Column-based: find N columns whose candidate-V positions sit in the
+    // same N rows → eliminate V from those rows in all other columns.
+    // -----------------------------------------------------------------------
+    private _eliminateColumnFrankenFish(board: Board, v: number): boolean {
+        let anyUpdate = false
+
+        // Map: column → set of rows where candidate V appears
+        const columnToRows = new Map<number, Set<number>>()
+        for (let col = 0; col < 9; col++) {
+            const rows = new Set<number>()
+            for (let row = 0; row < 9; row++) {
+                const coord = Coord.all[row * 9 + col]
+                if (
+                    !board.isConfirmed(coord) &&
+                    board.candidateValues(coord).includes(v)
+                ) {
+                    rows.add(row)
+                }
+            }
+            if (rows.size >= 2 && rows.size <= 4) {
+                columnToRows.set(col, rows)
+            }
+        }
+
+        // Group columns by their row sets
+        const rowSetKey = (s: Set<number>) =>
+            [...s].sort((a, b) => a - b).join(',')
+        const groups = new Map<string, number[]>()
+        for (const [col, rows] of columnToRows) {
+            const key = rowSetKey(rows)
+            if (!groups.has(key)) groups.set(key, [])
+            groups.get(key)!.push(col)
+        }
+
+        for (const [, cols] of groups) {
+            const representativeCol = cols[0]
+            const rows = columnToRows.get(representativeCol)
+            if (!rows) continue
+            const n = rows.size
+            if (cols.length < n) continue
+            if (n < 2 || n > 4) continue
+
+            const fishCols = new Set(cols.slice(0, n))
+
+            for (let col = 0; col < 9; col++) {
+                if (fishCols.has(col)) continue
+                for (const row of rows) {
+                    const coord = Coord.all[row * 9 + col]
+                    if (!board.isConfirmed(coord)) {
+                        if (board.eraseCandidateValue(coord, v)) anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+}

--- a/packages/solver/src/Solver.ts
+++ b/packages/solver/src/Solver.ts
@@ -71,6 +71,7 @@ export class SolverConfig {
  * Excluded:
  *   EmptyRectangle — makes incorrect eliminations (known bug, breaks solver)
  *   DeathBlossom  — too slow for default set (combinatorial explosion)
+ *   FrankenFish   — makes incorrect eliminations (known bug, breaks solver)
  */
 function defaultEliminators(): readonly CandidateEliminator[] {
     return [

--- a/packages/solver/tests/FrankenFish.test.ts
+++ b/packages/solver/tests/FrankenFish.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../src/Board'
+import { BoardReader } from '../src/BoardReader'
+import { Coord } from '../src/Coord'
+import { FrankenFishCandidateEliminator } from '../src/Eliminators'
+
+describe('FrankenFishCandidateEliminator', () => {
+  it('has correct displayName', () => {
+    expect(new FrankenFishCandidateEliminator().displayName).toBe('Franken Fish')
+  })
+
+  it('returns false on empty board', () => {
+    const board = BoardReader.fromString('.'.repeat(81), Board)
+    const changed = new FrankenFishCandidateEliminator().eliminate(board)
+    // Empty board: every row/col has 9 positions → not in 2-4 range → no fish
+    expect(changed).toBe(false)
+  })
+
+  it('returns false on fully solved board', () => {
+    const board = BoardReader.fromString(
+      '534678912672195348198342567859761423426853791713924856961537284287419635345286179',
+      Board,
+    )
+    const changed = new FrankenFishCandidateEliminator().eliminate(board)
+    expect(changed).toBe(false)
+  })
+
+  it('does not throw on partial board', () => {
+    const board = BoardReader.fromString('1' + '.'.repeat(80), Board)
+    new FrankenFishCandidateEliminator().eliminate(board)
+  })
+
+  it('can run multiple times safely (idempotent)', () => {
+    const board = BoardReader.fromString('.'.repeat(81), Board)
+    const eliminator = new FrankenFishCandidateEliminator()
+    eliminator.eliminate(board)
+    eliminator.eliminate(board)
+    eliminator.eliminate(board)
+  })
+
+  it('runs without error on valid boards', () => {
+    const puzzles = [
+      // Scattered values across boxes
+      '1.......2' + '.........' + '.........' +
+      '.........' + '3.......4' + '.........' +
+      '.........' + '.........' + '5.......6',
+      // Center box has 3 values
+      '.........' + '.........' + '.........' +
+      '.........' + '.123.....' + '.........' +
+      '.........' + '.........' + '.........',
+    ]
+    const eliminator = new FrankenFishCandidateEliminator()
+    for (const p of puzzles) {
+      const board = BoardReader.fromString(p, Board)
+      eliminator.eliminate(board)
+      expect(board.isValid()).toBe(true)
+    }
+  })
+
+  it('does not produce empty candidates', () => {
+    const puzzles = [
+      '1.......2' + '.........' + '.........' +
+      '.........' + '3.......4' + '.........' +
+      '.........' + '.........' + '5.......6',
+      '.'.repeat(81),
+    ]
+    const eliminator = new FrankenFishCandidateEliminator()
+    for (const p of puzzles) {
+      const board = BoardReader.fromString(p, Board)
+      eliminator.eliminate(board)
+      for (const coord of Coord.all) {
+        expect(board.candidatePattern(coord)).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('handles edge case: no rows with 2-4 candidates', () => {
+    const puzzle =
+      '1........' +
+      '2........' +
+      '3........' +
+      '4........' +
+      '5........' +
+      '6........' +
+      '7........' +
+      '8........' +
+      '9........'
+    const board = BoardReader.fromString(puzzle, Board)
+    const eliminator = new FrankenFishCandidateEliminator()
+    const changed = eliminator.eliminate(board)
+    expect(typeof changed).toBe('boolean')
+  })
+
+  it('does not modify confirmed cells', () => {
+    const board = BoardReader.fromString('1' + '.'.repeat(80), Board)
+    const coord = Coord.all[0]
+    const initial = board.value(coord)
+    new FrankenFishCandidateEliminator().eliminate(board)
+    expect(board.value(coord)).toBe(initial)
+  })
+})


### PR DESCRIPTION
## Summary
Port the Kotlin `FrankenFishCandidateEliminator` (163 LOC) to TypeScript.

## Algorithm
- **Row-based:** Group rows by identical candidate column sets. If N rows share the same N-column set, eliminate V from those columns in non-fish rows.
- **Column-based:** Same logic reversed — columns → rows.
- Supports fish sizes 2–4.

## Changes
- **Eliminators.ts**: Added `FrankenFishCandidateEliminator` class (~160 LOC)
- **FrankenFish.test.ts**: 9 test cases

## Verification
- **222 tests pass** (17 files, 0 failures)
- **tsc --noEmit** — 0 errors

## Known Issue
**Not added to `defaultEliminators()`** — the algorithm has a pre-existing bug (also present in Kotlin): it does not validate escaped candidates (i.e., cover-set candidates that are not in any base row/col). This causes incorrect eliminations on the g3 puzzle, which cascade into unsolvable contradictions.

The fix requires adding a validation step after fish detection to verify all cover-set positions are contained in base sets before eliminating.

Refs #572