### PR TITLE
fix: add value field to hint API response

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/TeachingHint.kt
+++ b/solver/src/main/java/will/sudoku/solver/TeachingHint.kt
@@ -6,6 +6,7 @@ package will.sudoku.solver
 data class TeachingHint(
     val type: HintType,
     val cell: Coord?,
+    val value: Int? = null,
     val technique: String,
     val explanation: String,
     val teachingPoints: List<String> = emptyList()
@@ -59,6 +60,7 @@ class TeachingHintProvider {
             return TeachingHint(
                 type = mapTechniqueToHintType(hintGenHint.technique),
                 cell = hintGenHint.coord,
+                value = hintGenHint.value,
                 technique = hintGenHint.technique.displayName,
                 explanation = hintGenHint.explanation,
                 teachingPoints = techniqueTeachingPoints(hintGenHint.technique)
@@ -148,6 +150,7 @@ class TeachingHintProvider {
                         return TeachingHint(
                             type = HintType.NAKED_SINGLE,
                             cell = coord,
+                            value = value,
                             technique = "Naked Single",
                             explanation = "Cell (${row + 1}, ${col + 1}) can only be $value! This is the only number that fits here.",
                             teachingPoints = listOf(

--- a/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/HintRoutes.kt
@@ -22,6 +22,7 @@ data class HintRequest(
 data class HintResponse(
     val type: String,
     val cell: CellCoordinate?,
+    val value: Int? = null,
     val technique: String,
     val explanation: String,
     val teachingPoints: List<String>
@@ -86,6 +87,7 @@ fun Route.hintRoutes() {
             HintResponse(
                 type = hint.type.name,
                 cell = hint.cell?.let { CellCoordinate(it.row, it.col) },
+                value = hint.value,
                 technique = hint.technique,
                 explanation = hint.explanation,
                 teachingPoints = hint.teachingPoints


### PR DESCRIPTION
## Summary
Fixes the hint API response missing the `value` field, which tells the caller what digit to place at the hinted cell.

## Root Cause
`HintGenerator.Hint` already has a `value: Int` field, but `TeachingHintProvider.getHint()` discarded it when constructing the `TeachingHint`. The `TeachingHint` data class and `HintResponse` serializable class lacked a `value` field entirely.

## Changes (2 files, +5 lines)
| File | Change |
|---|---|
| `TeachingHint.kt` | Added `val value: Int? = null` field; pass through in `getHint()` and `findNakedSingle()` |
| `HintRoutes.kt` | Added `val value: Int? = null` to `HintResponse`; pass `hint.value` through |

## Result
Hint API now returns:
```json
{"type": "NAKED_SINGLE", "cell": {"row": 1, "col": 0}, "value": 7, "technique": "Naked Single", "explanation": "Cell (2, 1) can only be 7!", "teachingPoints": ["..."]}
```

## Verification
- `./gradlew test` — all tests pass
- `./gradlew :web:installDist` — builds clean
- `value` is `null` for COMPLETE and fallback hints (no digit to place)

Closes #586