### PR TITLE
docs: slim repo-root AGENTS.md to thin dispatcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Sudoku Dojo
+
+Kotlin 2.1 (Ktor) backend + Vue 3 (TypeScript) frontend. Interactive sudoku learning app.
+
+## Before You Start
+- Read **[docs/UI-GUIDELINES.md](docs/UI-GUIDELINES.md)** — authoritative UI/UX reference
+- Read your role file in **[docs/agents/](docs/agents/)** — responsibilities, inputs, outputs, constraints
+
+## Agent Roles
+
+| Role | File | Responsibility |
+|------|------|---------------|
+| 🏗️ Architect | [docs/agents/architect.md](docs/agents/architect.md) | Roadmap, ADRs, direction |
+| 📋 Planner | [docs/agents/planner.md](docs/agents/planner.md) | Decompose issues, triage |
+| 💻 Coder | [docs/agents/coder.md](docs/agents/coder.md) | Implement features, fix bugs |
+| 🧪 Tester | [docs/agents/tester.md](docs/agents/tester.md) | QA, bug reports |
+| 👀 Reviewer | [docs/agents/reviewer.md](docs/agents/reviewer.md) | Code review, PR approval |
+| 🚀 Deployer | [docs/agents/deployer.md](docs/agents/deployer.md) | Deployment, monitoring |
+
+## Key Conventions
+- Empty cells: internal `.`, API `0`, UI shows **blank** (never `0` or `.`)
+- Pencil marks: `Record<string, number[]>` (cell index → candidate digits)
+- Stack: Kotlin 2.1 + Ktor → Vue 3 + Vite (SPA/PWA)


### PR DESCRIPTION
Refs #596

⚠️ **Merge after** #599 (UI guidelines), #600 (full AGENTS.md), and #601 (role files).

## Changes
- Replace full AGENTS.md (37 lines) with slim 23-line dispatcher
- One-line stack summary
- 'Before You Start' linking to UI guidelines and role files
- Role table with links to per-agent docs
- Key conventions footer

## Self-Review
- [x] Under 30 lines (23 lines)
- [x] Links to all 6 role files and UI guidelines
- [x] Concise — no duplicated content from role files
- [x] No code changes — docs only