### PR TITLE
feat: add difficulty field to tutorial responses

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
@@ -39,7 +39,8 @@ data class TutorialLesson(
     val description: String,
     val concept: String,
     val examplePuzzle: String,
-    val steps: List<TutorialStep>
+    val steps: List<TutorialStep>,
+    val difficulty: String = ""
 )
 
 @Serializable
@@ -51,6 +52,7 @@ data class TutorialSummary(
     val beltColor: String,
     val beltEmoji: String,
     val beltName: String,
+    val difficulty: String,
     val description: String,
     val completed: Boolean = false
 )
@@ -122,6 +124,21 @@ data class PracticeSet(
 )
 
 fun Route.tutorialRoutes() {
+    // Belt → difficulty mapping (from OpenAPI difficulty enum)
+    fun beltToDifficulty(belt: String): String = when (belt.lowercase()) {
+        "white" -> "EASY"
+        "yellow" -> "MEDIUM"
+        "orange" -> "MEDIUM"
+        "green" -> "HARD"
+        "blue" -> "HARD"
+        "purple" -> "EXPERT"
+        "brown" -> "EXPERT"
+        "red" -> "EXPERT"
+        "black" -> "MASTER"
+        "master" -> "MASTER"
+        else -> "MEDIUM"
+    }
+
     // Load lessons from JSON resource
     val lessonsJson = javaClass.classLoader
         .getResource("tutorials/lessons.json")
@@ -146,6 +163,7 @@ fun Route.tutorialRoutes() {
                 beltColor = lesson.beltColor,
                 beltEmoji = lesson.beltEmoji,
                 beltName = lesson.beltName,
+                difficulty = beltToDifficulty(lesson.belt),
                 description = lesson.description,
                 completed = completedTutorials.containsKey(lesson.id)
             )
@@ -173,7 +191,7 @@ fun Route.tutorialRoutes() {
             call.respond(HttpStatusCode.NotFound, ErrorResponse("Tutorial not found: $id"))
             return@get
         }
-        call.respond(lesson)
+        call.respond(lesson.copy(difficulty = beltToDifficulty(lesson.belt)))
     }
 
     // GET /tutorials/{id}/board — get example puzzle with candidates

--- a/web/src/main/resources/openapi/openapi.json
+++ b/web/src/main/resources/openapi/openapi.json
@@ -680,6 +680,7 @@
           "beltColor": {"type": "string"},
           "beltEmoji": {"type": "string"},
           "beltName": {"type": "string"},
+          "difficulty": {"type": "string", "description": "Difficulty level (EASY, MEDIUM, HARD, EXPERT, MASTER)"},
           "description": {"type": "string"},
           "completed": {"type": "boolean"}
         }
@@ -694,6 +695,7 @@
           "beltColor": {"type": "string"},
           "beltEmoji": {"type": "string"},
           "beltName": {"type": "string"},
+          "difficulty": {"type": "string", "description": "Difficulty level (EASY, MEDIUM, HARD, EXPERT, MASTER)"},
           "technique": {"type": "string"},
           "description": {"type": "string"},
           "concept": {"type": "string"},


### PR DESCRIPTION
Refs #604

## Changes
- Added belt→difficulty mapping function in TutorialRoutes
- Added `difficulty` field to TutorialSummary and TutorialLesson schemas
- Updated OpenAPI spec for both schemas

## Mapping
| Belt | Difficulty |
|------|-----------|
| white | EASY |
| yellow | MEDIUM |
| orange | MEDIUM |
| green | HARD |
| blue | HARD |
| purple | EXPERT |
| brown | EXPERT |
| red | EXPERT |
| black | MASTER |
| master | MASTER |

## Verification
- [x] All 389 tests pass
- [x] OpenAPI spec updated