### PR TITLE
feat: add intermediate technique exhaustion to HintGenerator (Refs #610)

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
+++ b/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
@@ -98,7 +98,16 @@ object HintGenerator {
             lastHiddenSingle = applyHiddenSinglesUntilStable(workingBoard)
         }
 
-        // Step 2.5: If the board is now solved, return the last hidden single found.
+        // Step 2.5: Exhaust intermediate techniques (pointing pairs, box/line reductions)
+        // before checking advanced techniques. Without this, harder puzzles may mask
+        // their first non-trivial technique behind pointing pairs/box-line reductions
+        // that need to be resolved first (Refs #610).
+        if (exhaustHiddenSingles) {
+            applyPointingPairsUntilStable(workingBoard)
+            applyBoxLineReductionsUntilStable(workingBoard)
+        }
+
+        // Step 2.6: If the board is now solved, return the last hidden single found.
         // Without this, puzzles solvable entirely by hidden singles would fall through
         // to the generic "Scanning" fallback (bug #224).
         if (workingBoard.isSolved() && lastHiddenSingle != null) {
@@ -246,6 +255,104 @@ object HintGenerator {
                 }
             }
         }
+        return eliminations
+    }
+
+    /**
+     * Apply box/line reductions to advance the board before checking for advanced techniques.
+     *
+     * Iteratively finds box/line reductions, eliminates the locked candidates, and re-runs
+     * constraint propagation. Continues until no more box/line reductions are found.
+     */
+    internal fun applyBoxLineReductionsUntilStable(board: Board) {
+        var foundAny = true
+        while (foundAny) {
+            foundAny = false
+            val eliminations = findBoxLineReductionEliminations(board)
+            if (eliminations.isNotEmpty()) {
+                foundAny = true
+                for ((coord, value) in eliminations) {
+                    board.eraseCandidatePattern(coord, Board.masks[value - 1])
+                }
+                applyBasicElimination(board)
+            }
+        }
+    }
+
+    /**
+     * Find all box/line reduction eliminations on the board.
+     * Returns a list of (coord, value) pairs to eliminate.
+     *
+     * Box/line reduction: When a candidate value in a row (or column) is restricted
+     * to cells within a single box, that value can be eliminated from the rest of that box.
+     */
+    private fun findBoxLineReductionEliminations(board: Board): List<Pair<Coord, Int>> {
+        val eliminations = mutableListOf<Pair<Coord, Int>>()
+
+        // Check each row for box/line reductions
+        for (row in 0..8) {
+            for (value in 1..9) {
+                val cells = mutableListOf<Coord>()
+                for (col in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) &&
+                        board.candidateValues(coord).contains(value)
+                    ) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size in 2..3) {
+                    val boxes = cells.map { Pair(it.row / 3, it.col / 3) }.toSet()
+                    if (boxes.size == 1) {
+                        val (boxRow, boxCol) = boxes.first()
+                        for (r in boxRow * 3 until (boxRow + 1) * 3) {
+                            if (r == row) continue
+                            for (c in boxCol * 3 until (boxCol + 1) * 3) {
+                                val coord = Coord(r, c)
+                                if (!board.isConfirmed(coord) &&
+                                    board.candidateValues(coord).contains(value)
+                                ) {
+                                    eliminations.add(Pair(coord, value))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check each column for box/line reductions
+        for (col in 0..8) {
+            for (value in 1..9) {
+                val cells = mutableListOf<Coord>()
+                for (row in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) &&
+                        board.candidateValues(coord).contains(value)
+                    ) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size in 2..3) {
+                    val boxes = cells.map { Pair(it.row / 3, it.col / 3) }.toSet()
+                    if (boxes.size == 1) {
+                        val (boxRow, boxCol) = boxes.first()
+                        for (c in boxCol * 3 until (boxCol + 1) * 3) {
+                            if (c == col) continue
+                            for (r in boxRow * 3 until (boxRow + 1) * 3) {
+                                val coord = Coord(r, c)
+                                if (!board.isConfirmed(coord) &&
+                                    board.candidateValues(coord).contains(value)
+                                ) {
+                                    eliminations.add(Pair(coord, value))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         return eliminations
     }
 

--- a/solver/src/test/java/will/sudoku/solver/HintGeneratorTest.kt
+++ b/solver/src/test/java/will/sudoku/solver/HintGeneratorTest.kt
@@ -88,4 +88,52 @@ class HintGeneratorTest {
         assertThat(HintGenerator.Technique.NAKED_PAIR.displayName).isEqualTo("Naked Pair")
         assertThat(HintGenerator.Technique.X_WING.displayName).isEqualTo("X-Wing")
     }
+
+    @Test
+    fun `generate does not crash on red belt Q1 puzzle with intermediate exhaustion`() {
+        // Red belt Q1 puzzle — tests that generate() runs intermediate exhaustion
+        // (pointing pairs + box/line reductions) without errors.
+        val puzzle = "800000000003600000070090200050007000000045700000100030001000068008500010090000400"
+        val board = BoardReader.readBoard(puzzle)
+
+        val hint = HintGenerator.generate(board)
+
+        // The generate() method should run without exceptions.
+        if (hint != null) {
+            assertThat(hint.technique).isNotNull
+            assertThat(hint.explanation).isNotBlank()
+            assertThat(hint.value).isIn(1..9)
+        }
+    }
+
+    @Test
+    fun `X-Wing puzzle still found after intermediate technique exhaustion`() {
+        // Same puzzle used in HintAdvancedTechniqueTest.
+        // Verifies that adding pointing pair/box-line exhaustion doesn't break
+        // existing technique detection.
+        val puzzle = "1.....5694.2.....8.5...9.4....64.8.1....1....2.8.35....4.5...1.9.....4.2621.....5"
+        val board = BoardReader.readBoard(puzzle)
+        SimpleCandidateEliminator().eliminate(board)
+
+        val hint = HintGenerator.generate(board)
+
+        assertThat(hint).isNotNull()
+        assertThat(hint!!.technique)
+            .`as`("After exhausting intermediate techniques, should still find an advanced technique")
+            .isNotEqualTo(HintGenerator.Technique.HIDDEN_SINGLE)
+    }
+
+    @Test
+    fun `applyPointingPairsUntilStable and applyBoxLineReductionsUntilStable are internal methods`() {
+        // Verify the exhaustion methods are accessible (internal visibility)
+        val puzzle = "800000000003600000070090200050007000000045700000100030001000068008500010090000400"
+        val board = BoardReader.readBoard(puzzle)
+        val workingBoard = board.copy()
+
+        // Should run without exceptions
+        HintGenerator.applyPointingPairsUntilStable(workingBoard)
+        HintGenerator.applyBoxLineReductionsUntilStable(workingBoard)
+
+        assertThat(workingBoard.isValid()).isTrue()
+    }
 }


### PR DESCRIPTION
## Summary
Adds intermediate technique exhaustion (pointing pairs + box/line reductions) to `HintGenerator.generate()` before checking advanced techniques. This ensures that pointing pairs and box/line reductions don't mask the first non-trivial technique on harder puzzles.

## Changes
- **`generate()`**: Now calls `applyPointingPairsUntilStable()` (previously defined but unused) and `applyBoxLineReductionsUntilStable()` after hidden singles exhaustion
- **New method `applyBoxLineReductionsUntilStable()`**: Iteratively finds and applies box/line reductions until stable
- **New method `findBoxLineReductionEliminations()`**: Detects all box/line reduction patterns on the board
- **Tests**: Added 3 new tests — red belt Q1 regression, X-Wing puzzle still works, and exhaustion method verification

## Why
When the board has pointing pairs or box/line reductions that can be resolved, they mask advanced techniques (X-Wing, Swordfish, XY-Wing, etc.). By exhausting these intermediate techniques first, `generate()` returns the actual next technique needed rather than falling through to null.

## Testing
- All existing tests pass (including HintAdvancedTechniqueTest)
- New tests verify exhaustion runs without errors
- No regressions on puzzles that already worked

Refs #610

## Checklist
- [x] All tests pass
- [x] Lint passes with zero warnings
- [x] Frontend builds clean
- [x] Backend distribution builds