### PR TITLE
fix: remove DeathBlossom from Kotlin default eliminators (Refs #583)

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
+++ b/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
@@ -52,8 +52,8 @@ data class SolverConfig(
             ForcingChainsCandidateEliminator(),
             ALSXZCandidateEliminator(),
             FrankenFishCandidateEliminator(),
-            MutantFishCandidateEliminator(),
-            DeathBlossomCandidateEliminator()
+            MutantFishCandidateEliminator()
+            // DeathBlossom excluded — too slow for default set (combinatorial explosion)
         )
 
         /**

--- a/solver/src/test/java/will/sudoku/solver/SolverConfigTest.kt
+++ b/solver/src/test/java/will/sudoku/solver/SolverConfigTest.kt
@@ -15,7 +15,7 @@ class SolverConfigTest {
     fun `default config includes all eliminators`() {
         val config = SolverConfig()
 
-        assertThat(config.eliminators).hasSize(16)
+        assertThat(config.eliminators).hasSize(15)
         assertThat(config.eliminators.map { it::class.simpleName }).containsExactly(
             "SimpleCandidateEliminator",
             "GroupCandidateEliminator",
@@ -31,8 +31,7 @@ class SolverConfigTest {
             "ForcingChainsCandidateEliminator",
             "ALSXZCandidateEliminator",
             "FrankenFishCandidateEliminator",
-            "MutantFishCandidateEliminator",
-            "DeathBlossomCandidateEliminator"
+            "MutantFishCandidateEliminator"
         )
     }
 
@@ -139,7 +138,7 @@ class SolverConfigTest {
         @Suppress("DEPRECATION")
         val eliminators = SolverConfig.defaultEliminators()
 
-        assertThat(eliminators).hasSize(16)
+        assertThat(eliminators).hasSize(15)
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Removes `DeathBlossomCandidateEliminator` from the Kotlin default eliminators set.

**Refs #583**

## Problem

DeathBlossom has high combinatorial complexity (ALS detection + petal enumeration) and slows down solving significantly. It was already excluded from the TS default eliminators but remained in the Kotlin `SolverConfig.defaultEliminators()`.

## Changes

| File | Change |
|------|--------|
| `SolverConfig.kt` | Removed `DeathBlossomCandidateEliminator()` from `defaultEliminators()` |
| `SolverConfigTest.kt` | Updated expected size from 16 → 15, removed from expected list |

## Test Results

```
✓ All Kotlin solver tests pass (BUILD SUCCESSFUL)
```

## Self-Review
- [x] PR description matches actual diff
- [x] No unrelated changes
- [x] Tests updated to match new behavior