### PR TITLE
feat: port MutantFish candidate position enumeration to TS (#619)

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -2,6 +2,15 @@ import type { Board } from './Board'
 import { Coord } from './Coord'
 import { CoordGroup } from './CoordGroup'
 import { bitCount, maskToValues, MASKS, SIZE, WILDCARD_PATTERN } from './Bitmask'
+import {
+    type House,
+    allHouses,
+    houseContains,
+    houseKey,
+    findCandidatePositions,
+    findHousesWithCandidates,
+    generateCombinations,
+} from './FishHelpers'
 
 // ---------------------------------------------------------------------------
 // CandidateEliminator interface
@@ -1484,5 +1493,133 @@ export class ALSXZCandidateEliminator implements CandidateEliminator {
             (Math.floor(a.row / 3) === Math.floor(b.row / 3) &&
                 Math.floor(a.col / 3) === Math.floor(b.col / 3))
         )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MutantFishCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Mutant Fish — the most advanced fish pattern where both base sets and
+ * cover sets can be a MIX of rows, columns, and boxes.
+ *
+ * A fish of size N for candidate V has:
+ * - N base sets (rows/cols/boxes) containing V positions
+ * - N cover sets that also contain those V positions
+ * - Every V position in a cover set must also be in a base set
+ * - Eliminate V from cover-set positions NOT in any base set
+ *
+ * Reference: https://www.sudopedia.org/wiki/Mutant_Fish
+ *
+ * Equivalent to the Kotlin `MutantFishCandidateEliminator`.
+ */
+export class MutantFishCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Mutant Fish'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+
+        for (let v = 1; v <= SIZE; v++) {
+            for (const size of [2, 3, 4]) {
+                if (this._findMutantFish(board, v, size)) {
+                    anyUpdate = true
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+
+    /**
+     * For a given candidate value and fish size, enumerate base-set
+     * combinations and attempt to find valid mutant fish patterns.
+     */
+    private _findMutantFish(board: Board, value: number, size: number): boolean {
+        const positions = findCandidatePositions(board, value)
+        if (positions.length < size * 2) return false
+
+        // Only consider houses with at least 2 candidate positions
+        const candidateHouses = findHousesWithCandidates(positions, 2)
+        if (candidateHouses.length < size) return false
+
+        const baseCombos = generateCombinations(candidateHouses, size)
+        let anyUpdate = false
+
+        for (const baseHouses of baseCombos) {
+            if (this._tryFishPattern(board, value, baseHouses, positions)) {
+                anyUpdate = true
+            }
+        }
+
+        return anyUpdate
+    }
+
+    /**
+     * Try a specific set of base houses as a mutant fish pattern.
+     *
+     * 1. Collect V positions in the base houses
+     * 2. Derive cover sets: houses that contain those V positions
+     * 3. Validate: exactly N cover sets, no V position escapes a base
+     * 4. Eliminate V from cover positions outside all base sets
+     */
+    private _tryFishPattern(
+        board: Board,
+        value: number,
+        baseHouses: readonly House[],
+        allPositions: readonly Coord[],
+    ): boolean {
+        const baseSet = new Set(baseHouses.map(houseKey))
+
+        // Find V positions in base houses
+        const fishPositions = allPositions.filter((coord) =>
+            baseHouses.some((h) => houseContains(h, coord)),
+        )
+        if (fishPositions.length === 0) return false
+
+        // Derive cover sets: all houses that contain at least one fish position
+        const coverHouses: House[] = []
+        const seenCovers = new Set<string>()
+        for (const house of allHouses) {
+            const key = houseKey(house)
+            if (seenCovers.has(key)) continue
+            if (fishPositions.some((c) => houseContains(house, c))) {
+                coverHouses.push(house)
+                seenCovers.add(key)
+            }
+        }
+
+        // Must have exactly N cover sets
+        if (coverHouses.length !== baseHouses.length) return false
+
+        // Validate: every V position in each cover house must be in a base house
+        for (const coverHouse of coverHouses) {
+            const vPositionsInCover = allPositions.filter((c) =>
+                houseContains(coverHouse, c),
+            )
+            const escaped = vPositionsInCover.some((coord) =>
+                baseHouses.every((h) => !houseContains(h, coord)),
+            )
+            if (escaped) return false
+        }
+
+        // Valid mutant fish — eliminate V from cover positions outside base sets
+        let anyUpdate = false
+        for (const coverHouse of coverHouses) {
+            for (const coord of Coord.all) {
+                if (
+                    houseContains(coverHouse, coord) &&
+                    !board.isConfirmed(coord) &&
+                    board.candidateValues(coord).includes(value) &&
+                    baseHouses.every((h) => !houseContains(h, coord))
+                ) {
+                    if (board.eraseCandidateValue(coord, value)) {
+                        anyUpdate = true
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
     }
 }

--- a/packages/solver/tests/MutantFish.test.ts
+++ b/packages/solver/tests/MutantFish.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../src/Board'
+import { BoardReader } from '../src/BoardReader'
+import { Coord } from '../src/Coord'
+import { MutantFishCandidateEliminator } from '../src/Eliminators'
+import {
+    findCandidatePositions,
+    findHousesWithCandidates,
+} from '../src/FishHelpers'
+
+describe('MutantFishCandidateEliminator', () => {
+    it('has correct displayName', () => {
+        expect(new MutantFishCandidateEliminator().displayName).toBe('Mutant Fish')
+    })
+
+    it('returns false on fully solved board', () => {
+        const board = BoardReader.fromString(
+            '534678912672195348198342567859761423426853791713924856961537284287419635345286179',
+            Board,
+        )
+        const changed = new MutantFishCandidateEliminator().eliminate(board)
+        expect(changed).toBe(false)
+    })
+
+    it('does not throw on a real-world puzzle', () => {
+        const board = BoardReader.fromString(
+            '53..7....' +
+            '6..195...' +
+            '.98....6.' +
+            '8...6...3' +
+            '4..8.3..1' +
+            '7...2...6' +
+            '.6....28.' +
+            '...419..5' +
+            '....8..79',
+            Board,
+        )
+        new MutantFishCandidateEliminator().eliminate(board)
+    })
+
+    it('does not modify confirmed cells', () => {
+        const board = BoardReader.fromString(
+            '53..7....' +
+            '6..195...' +
+            '.98....6.' +
+            '8...6...3' +
+            '4..8.3..1' +
+            '7...2...6' +
+            '.6....28.' +
+            '...419..5' +
+            '....8..79',
+            Board,
+        )
+        // Snapshot all confirmed values
+        const before: Map<Coord, number> = new Map()
+        for (const coord of Coord.all) {
+            if (board.isConfirmed(coord)) {
+                before.set(coord, board.value(coord))
+            }
+        }
+        new MutantFishCandidateEliminator().eliminate(board)
+        for (const [coord, val] of before) {
+            expect(board.value(coord)).toBe(val)
+        }
+    })
+
+    it('finds correct candidate positions via helpers', () => {
+        const puzzle =
+            '1........' +
+            '.1.......' +
+            '..1......' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........'
+        const board = BoardReader.fromString(puzzle, Board)
+        const positions = findCandidatePositions(board, 1)
+        // 3 placed 1s → 78 empty cells still have 1 as candidate
+        expect(positions.length).toBe(78)
+    })
+
+    it('enumerates base houses with at least 2 candidate positions', () => {
+        const puzzle =
+            '11.......' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........' +
+            '.........'
+        const board = BoardReader.fromString(puzzle, Board)
+        const positions = findCandidatePositions(board, 1)
+        const houses = findHousesWithCandidates(positions, 2)
+        expect(houses.some((h) => h.kind === 'row' && h.index === 0)).toBe(true)
+    })
+
+    it('produces valid results on a real-world puzzle', () => {
+        const eliminator = new MutantFishCandidateEliminator()
+        const puzzle =
+            '53..7....' +
+            '6..195...' +
+            '.98....6.' +
+            '8...6...3' +
+            '4..8.3..1' +
+            '7...2...6' +
+            '.6....28.' +
+            '...419..5' +
+            '....8..79'
+        const board = BoardReader.fromString(puzzle, Board)
+        const changed = eliminator.eliminate(board)
+        // Must not break board validity
+        expect(board.isValid()).toBe(true)
+        if (changed) {
+            expect(board.isSolved() || board.isValid()).toBe(true)
+        }
+    })
+})


### PR DESCRIPTION
Refs #619

## Changes
- Added `MutantFishCandidateEliminator` to `packages/solver/src/Eliminators.ts`
- Reuses shared fish helpers from FishHelpers.ts (House type, allHouses, findCandidatePositions, findHousesWithCandidates, generateCombinations)
- Ported core enumeration logic from Kotlin: enumerate N base sets (rows/cols/boxes), derive cover sets, validate, eliminate
- Created `packages/solver/tests/MutantFish.test.ts` with 7 test cases

## Implementation Details
The MutantFish eliminator scans combinations of N houses (2-4) as base sets, collects candidate V positions within those bases, derives cover sets, validates that all V positions in cover houses are within base houses, and eliminates V from cover positions outside base sets.

## Testing
- [x] All 7 MutantFish tests pass
- [x] Full test suite passes (no regressions)
- [x] Build succeeds

## Self-Review
- [x] PR description matches actual diff
- [x] No unrelated changes
- [x] Tests included