### PR TITLE
perf: optimize MutantFish elimination loop (v2, Refs #620)

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -1764,9 +1764,9 @@ export class MutantFishCandidateEliminator implements CandidateEliminator {
         // Valid mutant fish — eliminate V from cover positions outside base sets
         let anyUpdate = false
         for (const coverHouse of coverHouses) {
-            for (const coord of Coord.all) {
+            // Only iterate coords that are actually in this cover house
+            for (const coord of coverHouse.coords) {
                 if (
-                    houseContains(coverHouse, coord) &&
                     !board.isConfirmed(coord) &&
                     board.candidateValues(coord).includes(value) &&
                     baseHouses.every((h) => !houseContains(h, coord))


### PR DESCRIPTION
Refs #620

## Changes
- Optimized MutantFish elimination loop: iterate cover house coords directly () instead of all 81 coords with  check
- Clean branch based on current master — no stale code, no unrelated changes

## Note
MutantFish cover set logic is complete and working. However, **integration into `defaultEliminators()` is still blocked by ~10s performance regression** due to combinatorial explosion of house combinations (27 houses, combinations of 2-4).

## Testing
- [x] All MutantFish tests pass (7/7)
- [x] Full solver test suite passes (283/283)
- [x] No regression in existing tests