### PR TITLE
feat: port UniqueRectanglesCandidateEliminator to TypeScript

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -1279,6 +1279,138 @@ export class XYZWingCandidateEliminator implements CandidateEliminator {
 }
 
 // ---------------------------------------------------------------------------
+// UniqueRectanglesCandidateEliminator
+// ---------------------------------------------------------------------------
+
+/**
+ * Unique Rectangles elimination technique, Type 1.
+ *
+ * Detects deadly rectangle patterns based on the uniqueness constraint:
+ * a proper Sudoku puzzle has exactly one solution. A deadly pattern would
+ * create multiple solutions, so candidates that force it can be eliminated.
+ *
+ * A deadly rectangle consists of 4 cells at (r1,c1), (r1,c2), (r2,c1),
+ * (r2,c2) where all 4 contain the same 2 candidates {X, Y}. They must span
+ * exactly 2 rows, 2 columns, and 2 different 3×3 boxes.
+ *
+ * Type 1 (Single Extra Candidate): If exactly one of the 4 cells has
+ * additional candidates beyond {X, Y}, then X and Y can be eliminated from
+ * that cell, leaving only the extra candidates.
+ *
+ * Reference:
+ * - https://www.sudokuwiki.org/Unique_Rectangles (SudokuWiki)
+ * - https://www.sudopedia.org/wiki/Unique_Rectangle
+ *
+ * Equivalent to the Kotlin `UniqueRectanglesCandidateEliminator`.
+ */
+export class UniqueRectanglesCandidateEliminator implements CandidateEliminator {
+    readonly displayName = 'Unique Rectangles'
+
+    eliminate(board: Board): boolean {
+        let anyUpdate = false
+
+        for (let r1 = 0; r1 < 8; r1++) {
+            for (let r2 = r1 + 1; r2 < 9; r2++) {
+                for (let c1 = 0; c1 < 8; c1++) {
+                    for (let c2 = c1 + 1; c2 < 9; c2++) {
+                        const corners: Coord[] = [
+                            Coord.all[r1 * 9 + c1],
+                            Coord.all[r1 * 9 + c2],
+                            Coord.all[r2 * 9 + c1],
+                            Coord.all[r2 * 9 + c2],
+                        ]
+
+                        const pattern = this._findDeadlyRectangle(board, corners)
+                        if (pattern != null) {
+                            if (this._applyType1(board, corners, pattern[0], pattern[1])) {
+                                anyUpdate = true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+
+    private _findDeadlyRectangle(
+        board: Board,
+        corners: Coord[],
+    ): [number, number] | null {
+        for (const coord of corners) {
+            if (board.isConfirmed(coord)) return null
+        }
+
+        const box1 = this._getBoxIndex(corners[0])
+        const box2 = this._getBoxIndex(corners[1])
+        const box3 = this._getBoxIndex(corners[2])
+        const box4 = this._getBoxIndex(corners[3])
+
+        if (box1 !== box3 || box2 !== box4) return null
+        if (box1 === box2) return null
+
+        const candidatesList = corners.map((c) => [
+            ...maskToValues(board.candidatePattern(c)),
+        ])
+
+        const common = this._intersectAll(candidatesList)
+        if (common.length < 2 || common.length !== 2) return null
+
+        const [x, y] = common
+
+        const cellsWithExtras = candidatesList.filter((c) => c.length > 2).length
+        const cellsWithTwo = candidatesList.filter((c) => c.length === 2).length
+
+        if (cellsWithExtras < 1 || cellsWithTwo < 3) return null
+
+        return [x, y]
+    }
+
+    private _applyType1(
+        board: Board,
+        corners: Coord[],
+        x: number,
+        y: number,
+    ): boolean {
+        let anyUpdate = false
+        const maskX = MASKS[x - 1]
+        const maskY = MASKS[y - 1]
+
+        const cellsWithExtras = corners.filter((coord) => {
+            const pattern = board.candidatePattern(coord)
+            return (
+                (pattern & maskX) !== 0 &&
+                (pattern & maskY) !== 0 &&
+                bitCount(pattern) > 2
+            )
+        })
+
+        if (cellsWithExtras.length === 1) {
+            const target = cellsWithExtras[0]
+            const erasedX = board.eraseCandidateValue(target, x)
+            const erasedY = board.eraseCandidateValue(target, y)
+            if (erasedX || erasedY) anyUpdate = true
+        }
+
+        return anyUpdate
+    }
+
+    private _getBoxIndex(coord: Coord): number {
+        return Math.floor(coord.row / 3) * 3 + Math.floor(coord.col / 3)
+    }
+
+    private _intersectAll(lists: number[][]): number[] {
+        if (lists.length === 0) return []
+        let result = new Set(lists[0])
+        for (let i = 1; i < lists.length; i++) {
+            result = new Set(lists[i].filter((v) => result.has(v)))
+        }
+        return [...result]
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DeathBlossomCandidateEliminator
 // ---------------------------------------------------------------------------
 

--- a/packages/solver/src/Solver.ts
+++ b/packages/solver/src/Solver.ts
@@ -13,6 +13,7 @@ import {
     WWingCandidateEliminator,
     XYWingCandidateEliminator,
     XYZWingCandidateEliminator,
+    UniqueRectanglesCandidateEliminator,
     ALSXZCandidateEliminator,
 } from './Eliminators'
 import { Coord } from './Coord'
@@ -89,6 +90,7 @@ function defaultEliminators(): readonly CandidateEliminator[] {
         new WWingCandidateEliminator(),
         new XYWingCandidateEliminator(),
         new XYZWingCandidateEliminator(),
+        new UniqueRectanglesCandidateEliminator(),
         new ALSXZCandidateEliminator(),
     ]
 }

--- a/packages/solver/tests/UniqueRectangles.test.ts
+++ b/packages/solver/tests/UniqueRectangles.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import { Board } from '../src/Board'
+import { Coord } from '../src/Coord'
+import {
+    SimpleCandidateEliminator,
+    UniqueRectanglesCandidateEliminator,
+} from '../src/Eliminators'
+
+describe('UniqueRectanglesCandidateEliminator', () => {
+    it('no changes when board is fully solved', () => {
+        const values = new Int8Array([
+            5, 4, 9, 3, 7, 8, 1, 6, 2,
+            2, 1, 7, 4, 6, 5, 3, 9, 8,
+            6, 3, 8, 2, 9, 1, 4, 7, 5,
+            9, 2, 3, 5, 4, 6, 7, 8, 1,
+            1, 7, 4, 8, 2, 9, 5, 3, 6,
+            8, 6, 5, 7, 1, 3, 9, 2, 4,
+            4, 5, 2, 9, 8, 7, 6, 1, 3,
+            3, 9, 1, 6, 5, 2, 8, 4, 7,
+            7, 8, 6, 1, 3, 4, 2, 5, 9,
+        ])
+
+        const board = Board.fromValues(values)
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        const changed = eliminator.eliminate(board)
+
+        expect(changed).toBe(false)
+    })
+
+    it('runs without error on empty board', () => {
+        const values = new Int8Array(81)
+        const board = Board.fromValues(values)
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+
+        const changed = eliminator.eliminate(board)
+
+        // All cells have 9 candidates, no deadly rectangle forms
+        expect(changed).toBe(false)
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('runs without error on partial board', () => {
+        const values = new Int8Array(81)
+        values[0] = 1
+        values[40] = 5
+        values[80] = 9
+
+        const board = Board.fromValues(values)
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('does not modify confirmed cells', () => {
+        const values = new Int8Array(81)
+        values[0] = 1
+
+        const board = Board.fromValues(values)
+        const initialPattern = board.candidatePattern(Coord.all[0])
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        eliminator.eliminate(board)
+
+        expect(board.candidatePattern(Coord.all[0])).toBe(initialPattern)
+    })
+
+    it('handles rectangle at board corners', () => {
+        // (0,0), (0,1), (1,0), (1,1)
+        const values = new Int8Array(81)
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('handles rectangle at board center', () => {
+        // (4,4), (4,5), (5,4), (5,5)
+        const values = new Int8Array(81)
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('handles complex board state', () => {
+        const values = new Int8Array([
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 1, 2, 3, 0, 0, 0,
+            0, 0, 0, 4, 5, 6, 0, 0, 0,
+            0, 0, 0, 7, 8, 9, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ])
+
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('Type 1 pattern not falsely detected when multiple cells have extras', () => {
+        const values = new Int8Array(81)
+        // Every other cell filled — complex candidate state
+        for (let i = 0; i < 81; i += 2) {
+            values[i] = (i % 9) + 1
+        }
+
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        const result = eliminator.eliminate(board)
+        expect(typeof result).toBe('boolean')
+    })
+
+    it('handles same-box corner detection correctly', () => {
+        const values = new Int8Array(81)
+        // Fill box 0 (top-left 3×3)
+        values[0] = 1
+        values[1] = 2
+        values[2] = 3
+        values[9] = 4
+        values[10] = 5
+        values[11] = 6
+
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('handles board after basic elimination', () => {
+        const values = new Int8Array(81)
+        values[0] = 1
+        values[4] = 5
+        values[8] = 9
+        values[10] = 2
+        values[20] = 8
+        values[40] = 7
+        values[50] = 3
+        values[60] = 4
+        values[80] = 6
+
+        const board = Board.fromValues(values)
+        new SimpleCandidateEliminator().eliminate(board)
+
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(() => eliminator.eliminate(board)).not.toThrow()
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('can run multiple times safely', () => {
+        const values = new Int8Array([
+            5, 4, 9, 3, 7, 8, 1, 6, 2,
+            2, 1, 7, 4, 6, 5, 3, 9, 8,
+            6, 3, 8, 2, 9, 1, 4, 7, 5,
+            9, 2, 3, 5, 4, 6, 7, 8, 1,
+            1, 7, 4, 8, 2, 9, 5, 3, 6,
+            8, 6, 5, 7, 1, 3, 9, 2, 4,
+            4, 5, 2, 9, 8, 7, 6, 1, 3,
+            3, 9, 1, 6, 5, 2, 8, 4, 7,
+            7, 8, 6, 1, 3, 4, 2, 5, 9,
+        ])
+
+        const board = Board.fromValues(values)
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+
+        eliminator.eliminate(board)
+        eliminator.eliminate(board)
+        eliminator.eliminate(board)
+
+        expect(board.isValid()).toBe(true)
+    })
+
+    it('eliminator has correct display name', () => {
+        const eliminator = new UniqueRectanglesCandidateEliminator()
+        expect(eliminator.displayName).toBe('Unique Rectangles')
+    })
+})


### PR DESCRIPTION
Refs #570

## Summary
Ports the Kotlin `UniqueRectanglesCandidateEliminator` (Type 1 only) to TypeScript in `packages/solver/src/Eliminators.ts`.

## Algorithm
Unique Rectangles exploits the uniqueness constraint - a valid puzzle has exactly one solution. A deadly pattern (4 cells with same 2 candidates across 2 rows, 2 cols, 2 boxes) would create multiple solutions.

- **Type 1:** If exactly one of the 4 cells has extra candidates beyond `{X, Y}`, eliminate X and Y from that cell

## Changes
- `Eliminators.ts (+132):` Added `UniqueRectanglesCandidateEliminator` class with rectangle detection and Type 1 elimination
- `Solver.ts (+2):` Added import + registration in `defaultEliminators()`
- `UniqueRectangles.test.ts (+191):` 12 test cases

## Verification
- 304/304 TS tests pass (24 test files)
- Lint clean (0 warnings)
- Frontend builds cleanly
- Reference: https://www.sudokuwiki.org/Unique_Rectangles (SudokuWiki)

Refs #566 (epic: port 9 missing eliminators)