### PR TITLE
fix: increase MutantFish test timeout to 15s (Refs #652)

### DIFF
--- a/packages/solver/tests/MutantFish.test.ts
+++ b/packages/solver/tests/MutantFish.test.ts
@@ -8,7 +8,7 @@ import {
     findHousesWithCandidates,
 } from '../src/FishHelpers'
 
-describe('MutantFishCandidateEliminator', () => {
+describe('MutantFishCandidateEliminator', { timeout: 15000 }, () => {
     it('has correct displayName', () => {
         expect(new MutantFishCandidateEliminator().displayName).toBe('Mutant Fish')
     })


### PR DESCRIPTION
## Summary

3 MutantFish tests using real-world puzzles consistently take 4.3-5.5s each, exceeding vitest's default 5s per-test timeout. This causes spurious CI failures.

## Changes

- Add `{ timeout: 15000 }` to the MutantFishCandidateEliminator describe block
- All 7 tests pass: ✓ 14224ms total

## Testing
- `npx vitest run tests/MutantFish.test.ts` — 7/7 passed (16.4s total)
- No functional changes

Refs #652