### PR TITLE
fix: WWingCandidateEliminator board corruption (Refs #653)

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -938,13 +938,7 @@ export class WWingCandidateEliminator implements CandidateEliminator {
     readonly displayName = 'W-Wing'
 
     eliminate(board: Board): boolean {
-        let anyUpdate = false
-        let stable: boolean
-        do {
-            stable = true
-            if (this._eliminateWings(board)) { anyUpdate = true; stable = false }
-        } while (!stable)
-        return anyUpdate
+        return this._eliminateWings(board)
     }
 
     private _eliminateWings(board: Board): boolean {
@@ -982,9 +976,9 @@ export class WWingCandidateEliminator implements CandidateEliminator {
     }
 
     private _checkWWing(board: Board, a: Coord, b: Coord, link: number, target: number): boolean {
-        // Find cells with 'link' candidate that see cell a
-        const linkCellsA = this._findLinkCells(board, a, link)
-        const linkCellsB = this._findLinkCells(board, b, link)
+        // Find cells with 'link' candidate that see cell a (but are not a or b)
+        const linkCellsA = this._findLinkCells(board, a, link, b)
+        const linkCellsB = this._findLinkCells(board, b, link, a)
 
         for (const la of linkCellsA) {
             for (const lb of linkCellsB) {
@@ -997,11 +991,12 @@ export class WWingCandidateEliminator implements CandidateEliminator {
         return false
     }
 
-    private _findLinkCells(board: Board, cell: Coord, candidate: number): Coord[] {
+    private _findLinkCells(board: Board, cell: Coord, candidate: number, exclude?: Coord): Coord[] {
         const mask = MASKS[candidate - 1]
         const result: Coord[] = []
         for (const coord of Coord.all) {
             if (coord === cell) continue
+            if (exclude && coord === exclude) continue
             if (!(board.candidatePattern(coord) & mask)) continue
             if (this._seesEachOther(coord, cell)) result.push(coord)
         }


### PR DESCRIPTION
## Description
Fixes the WWingCandidateEliminator board corruption bug described in #653.

**This PR contains ONLY the code fix — separate from the tutorial puzzle data changes.**

## Root Cause
Two issues:

### 1. `_findLinkCells` including the partner bi-value cell
The method only excluded the passed `cell` from link cell searches. When called for cell `a`, it would include the partner bi-value cell `b` if `b` also contained the link candidate and saw `a`. This created false-positive W-Wing detections.

**Fix:** Added optional `exclude` param; `_checkWWing` now passes the partner cell so it is excluded from both searches.

### 2. Do-while loop in `eliminate()` causing cascading incorrect eliminations
Each wing elimination changed the bi-value cell landscape, creating NEW wings that could over-eliminate. The cascade produced contradictions (e.g., two cells in the same row both confirmed as 4).

**Fix:** Removed the do-while loop — `eliminate()` runs `_eliminateWings` once per call. The outer solver loop handles multi-wing puzzles naturally.

## Testing
- Puzzle `000001008700030009020000061080009003001040900900300020240000080600090005100600000` now solves correctly
- All 323 existing tests pass

Refs #653