### PR TITLE
feat: extract TechniqueDetector interface and 4 simple detectors

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
+++ b/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
@@ -1,5 +1,10 @@
 package will.sudoku.solver
 
+import will.sudoku.solver.detectors.BoxLineReductionDetector
+import will.sudoku.solver.detectors.HiddenSingleDetector
+import will.sudoku.solver.detectors.NakedSingleDetector
+import will.sudoku.solver.detectors.PointingPairDetector
+
 /**
  * Hint Generator
  *
@@ -162,7 +167,7 @@ object HintGenerator {
             var foundOne: Boolean
             do {
                 foundOne = false
-                val hint = findHiddenSingle(board)
+                val hint = hiddenSingleDetector.detect(board)
                 if (hint != null) {
                     board.markValue(hint.coord, hint.value)
                     lastHint = hint
@@ -360,11 +365,17 @@ object HintGenerator {
      * Detect a specific technique on the board.
      * Runs the corresponding detection method and returns a hint if found.
      */
+    private val nakedSingleDetector = NakedSingleDetector()
+    private val hiddenSingleDetector = HiddenSingleDetector()
+    private val pointingPairDetector = PointingPairDetector()
+    private val boxLineReductionDetector = BoxLineReductionDetector()
+
     private fun detectTechnique(board: Board, technique: Technique): Hint? {
         return when (technique) {
-            Technique.NAKED_SINGLE -> findNakedSingle(board)
-            Technique.HIDDEN_SINGLE -> findHiddenSingle(board)
-            Technique.POINTING_PAIR -> findPointingPair(board)
+            Technique.NAKED_SINGLE -> nakedSingleDetector.detect(board)
+            Technique.HIDDEN_SINGLE -> hiddenSingleDetector.detect(board)
+            Technique.POINTING_PAIR -> pointingPairDetector.detect(board)
+            Technique.BOX_LINE_REDUCTION -> boxLineReductionDetector.detect(board)
             Technique.NAKED_PAIR -> findNakedPair(board)
             Technique.NAKED_TRIPLE -> findNakedTriple(board)
             Technique.HIDDEN_PAIR -> findHiddenPair(board)
@@ -381,7 +392,6 @@ object HintGenerator {
             Technique.MUTANT_FISH -> findTechniqueViaEliminator(board, Technique.MUTANT_FISH, MutantFishCandidateEliminator())
             Technique.DEATH_BLOSSOM -> findTechniqueViaEliminator(board, Technique.DEATH_BLOSSOM, DeathBlossomCandidateEliminator())
             Technique.FORCING_CHAINS -> findTechniqueViaEliminator(board, Technique.FORCING_CHAINS, ForcingChainsCandidateEliminator())
-            Technique.BOX_LINE_REDUCTION -> findBoxLineReduction(board)
         }
     }
 

--- a/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
+++ b/solver/src/main/java/will/sudoku/solver/HintGenerator.kt
@@ -1,9 +1,17 @@
 package will.sudoku.solver
 
 import will.sudoku.solver.detectors.BoxLineReductionDetector
+import will.sudoku.solver.detectors.HiddenPairDetector
 import will.sudoku.solver.detectors.HiddenSingleDetector
+import will.sudoku.solver.detectors.HiddenTripleDetector
+import will.sudoku.solver.detectors.NakedPairDetector
 import will.sudoku.solver.detectors.NakedSingleDetector
+import will.sudoku.solver.detectors.NakedTripleDetector
 import will.sudoku.solver.detectors.PointingPairDetector
+import will.sudoku.solver.detectors.SwordfishDetector
+import will.sudoku.solver.detectors.XYWingDetector
+import will.sudoku.solver.detectors.XWingDetector
+import will.sudoku.solver.detectors.XYZWingDetector
 
 /**
  * Hint Generator
@@ -369,6 +377,14 @@ object HintGenerator {
     private val hiddenSingleDetector = HiddenSingleDetector()
     private val pointingPairDetector = PointingPairDetector()
     private val boxLineReductionDetector = BoxLineReductionDetector()
+    private val nakedPairDetector = NakedPairDetector()
+    private val nakedTripleDetector = NakedTripleDetector()
+    private val hiddenPairDetector = HiddenPairDetector()
+    private val hiddenTripleDetector = HiddenTripleDetector()
+    private val xWingDetector = XWingDetector()
+    private val swordfishDetector = SwordfishDetector()
+    private val xyWingDetector = XYWingDetector()
+    private val xyzWingDetector = XYZWingDetector()
 
     private fun detectTechnique(board: Board, technique: Technique): Hint? {
         return when (technique) {
@@ -376,14 +392,14 @@ object HintGenerator {
             Technique.HIDDEN_SINGLE -> hiddenSingleDetector.detect(board)
             Technique.POINTING_PAIR -> pointingPairDetector.detect(board)
             Technique.BOX_LINE_REDUCTION -> boxLineReductionDetector.detect(board)
-            Technique.NAKED_PAIR -> findNakedPair(board)
-            Technique.NAKED_TRIPLE -> findNakedTriple(board)
-            Technique.HIDDEN_PAIR -> findHiddenPair(board)
-            Technique.HIDDEN_TRIPLE -> findHiddenTriple(board)
-            Technique.X_WING -> findXWing(board)
-            Technique.SWORDFISH -> findSwordfish(board)
-            Technique.XY_WING -> findXYWing(board)
-            Technique.XYZ_WING -> findXYZWWing(board)
+            Technique.NAKED_PAIR -> nakedPairDetector.detect(board)
+            Technique.NAKED_TRIPLE -> nakedTripleDetector.detect(board)
+            Technique.HIDDEN_PAIR -> hiddenPairDetector.detect(board)
+            Technique.HIDDEN_TRIPLE -> hiddenTripleDetector.detect(board)
+            Technique.X_WING -> xWingDetector.detect(board)
+            Technique.SWORDFISH -> swordfishDetector.detect(board)
+            Technique.XY_WING -> xyWingDetector.detect(board)
+            Technique.XYZ_WING -> xyzWingDetector.detect(board)
             Technique.W_WING -> findTechniqueViaEliminator(board, Technique.W_WING, WWingCandidateEliminator())
             Technique.SIMPLE_COLORING -> findTechniqueViaEliminator(board, Technique.SIMPLE_COLORING, SimpleColoringCandidateEliminator())
             Technique.UNIQUE_RECTANGLE -> findTechniqueViaEliminator(board, Technique.UNIQUE_RECTANGLE, UniqueRectanglesCandidateEliminator())

--- a/solver/src/main/java/will/sudoku/solver/TechniqueDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/TechniqueDetector.kt
@@ -1,0 +1,25 @@
+package will.sudoku.solver
+
+/**
+ * Interface for technique-specific hint detection.
+ *
+ * Each implementation detects a single sudoku technique and returns
+ * a [HintGenerator.Hint] if the technique is applicable to the given board state.
+ *
+ * Implementations should be stateless and side-effect-free — they read the board
+ * but do not modify it.
+ */
+interface TechniqueDetector {
+    /**
+     * The technique this detector identifies.
+     */
+    val technique: HintGenerator.Technique
+
+    /**
+     * Detect whether this technique applies to the given board.
+     *
+     * @param board The current board state (must not be modified)
+     * @return A hint if the technique is found, null otherwise
+     */
+    fun detect(board: Board): HintGenerator.Hint?
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/BoxLineReductionDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/BoxLineReductionDetector.kt
@@ -1,0 +1,96 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects box/line reductions — candidates restricted to one box in a row or column.
+ */
+class BoxLineReductionDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.BOX_LINE_REDUCTION
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        // Check rows for box/line reduction
+        for (row in 0..8) {
+            for (value in 1..9) {
+                val cells = mutableListOf<Coord>()
+                for (col in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) &&
+                        value in board.candidateValues(coord)
+                    ) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size in 2..3) {
+                    val boxes = cells.map { Pair(it.row / 3, it.col / 3) }.toSet()
+                    if (boxes.size == 1) {
+                        val (boxRow, boxCol) = boxes.first()
+                        for (r in boxRow * 3 until (boxRow + 1) * 3) {
+                            if (r == row) continue
+                            for (c in boxCol * 3 until (boxCol + 1) * 3) {
+                                val coord = Coord(r, c)
+                                if (!board.isConfirmed(coord) &&
+                                    value in board.candidateValues(coord)
+                                ) {
+                                    return HintGenerator.Hint(
+                                        coord = coord,
+                                        value = value,
+                                        technique = technique,
+                                        explanation = "Value $value in row ${row + 1} " +
+                                                "is restricted to box (${boxRow + 1},${boxCol + 1}). " +
+                                                "Eliminate $value from other rows in this box."
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Check columns for box/line reduction
+        for (col in 0..8) {
+            for (value in 1..9) {
+                val cells = mutableListOf<Coord>()
+                for (row in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) &&
+                        value in board.candidateValues(coord)
+                    ) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size in 2..3) {
+                    val boxes = cells.map { Pair(it.row / 3, it.col / 3) }.toSet()
+                    if (boxes.size == 1) {
+                        val (boxRow, boxCol) = boxes.first()
+                        for (c in boxCol * 3 until (boxCol + 1) * 3) {
+                            if (c == col) continue
+                            for (r in boxRow * 3 until (boxRow + 1) * 3) {
+                                val coord = Coord(r, c)
+                                if (!board.isConfirmed(coord) &&
+                                    value in board.candidateValues(coord)
+                                ) {
+                                    return HintGenerator.Hint(
+                                        coord = coord,
+                                        value = value,
+                                        technique = technique,
+                                        explanation = "Value $value in column ${col + 1} " +
+                                                "is restricted to box (${boxRow + 1},${boxCol + 1}). " +
+                                                "Eliminate $value from other columns in this box."
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/CoordUtils.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/CoordUtils.kt
@@ -1,0 +1,25 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Coord
+
+/**
+ * Utility functions for coordinate-based checks used by technique detectors.
+ */
+internal object CoordUtils {
+
+    /**
+     * Check if two cells see each other (same row, column, or region).
+     */
+    fun seesEachOther(coord1: Coord, coord2: Coord): Boolean {
+        return coord1.row == coord2.row ||
+                coord1.col == coord2.col ||
+                sameRegion(coord1, coord2)
+    }
+
+    /**
+     * Check if two cells are in the same 3x3 region.
+     */
+    fun sameRegion(coord1: Coord, coord2: Coord): Boolean {
+        return coord1.row / 3 == coord2.row / 3 && coord1.col / 3 == coord2.col / 3
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/HiddenPairDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/HiddenPairDetector.kt
@@ -1,0 +1,71 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.CoordGroup
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects hidden pairs — two values that appear only in the same two cells within a group.
+ */
+class HiddenPairDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.HIDDEN_PAIR
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coordGroup in CoordGroup.all) {
+            val valueToCells = mutableMapOf<Int, MutableList<will.sudoku.solver.Coord>>()
+            for (value in 1..9) {
+                val cells = mutableListOf<will.sudoku.solver.Coord>()
+                for (coord in coordGroup.coords) {
+                    if (!board.isConfirmed(coord) && value in board.candidateValues(coord)) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size == 2) {
+                    valueToCells[value] = cells
+                }
+            }
+
+            val values = valueToCells.keys.toList()
+            for (i in values.indices) {
+                for (j in i + 1 until values.size) {
+                    val v1 = values[i]
+                    val v2 = values[j]
+                    val cells1 = valueToCells[v1]!!.toSet()
+                    val cells2 = valueToCells[v2]!!.toSet()
+
+                    if (cells1 == cells2 && cells1.size == 2) {
+                        val cells = cells1.toList()
+                        val extraCandidates1 = board.candidateValues(cells[0]).filter { it != v1 && it != v2 }
+                        val extraCandidates2 = board.candidateValues(cells[1]).filter { it != v1 && it != v2 }
+
+                        if (extraCandidates1.isNotEmpty()) {
+                            return HintGenerator.Hint(
+                                coord = cells[0],
+                                value = extraCandidates1.first(),
+                                technique = technique,
+                                explanation = "Values $v1 and $v2 form a hidden pair in cells " +
+                                        "(${cells[0].row + 1},${cells[0].col + 1}) and " +
+                                        "(${cells[1].row + 1},${cells[1].col + 1}). " +
+                                        "Other candidates can be eliminated from these cells."
+                            )
+                        }
+                        if (extraCandidates2.isNotEmpty()) {
+                            return HintGenerator.Hint(
+                                coord = cells[1],
+                                value = extraCandidates2.first(),
+                                technique = technique,
+                                explanation = "Values $v1 and $v2 form a hidden pair in cells " +
+                                        "(${cells[0].row + 1},${cells[0].col + 1}) and " +
+                                        "(${cells[1].row + 1},${cells[1].col + 1}). " +
+                                        "Other candidates can be eliminated from these cells."
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/HiddenSingleDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/HiddenSingleDetector.kt
@@ -1,0 +1,59 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.CoordGroup
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects hidden singles — values that appear only once in a row, column, or region.
+ */
+class HiddenSingleDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.HIDDEN_SINGLE
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coordGroup in CoordGroup.all) {
+            val knownValues = coordGroup.coords.map { board.value(it) }.toSet()
+
+            // Count occurrences of each candidate in the group
+            val candidateCounts = mutableMapOf<Int, MutableList<Coord>>()
+
+            for (coord in coordGroup.coords) {
+                if (board.isConfirmed(coord)) continue
+                for (candidate in board.candidateValues(coord)) {
+                    candidateCounts.getOrPut(candidate) { mutableListOf() }.add(coord)
+                }
+            }
+
+            // Find candidates that appear only once
+            for ((value, coords) in candidateCounts) {
+                if (coords.size == 1 && value !in knownValues) {
+                    val coord = coords[0]
+                    // Determine which type of group this is based on the coordinates
+                    val firstCoord = coordGroup.coords[0]
+                    val lastCoord = coordGroup.coords[8]
+                    val groupName = when {
+                        firstCoord.row == lastCoord.row -> "row ${firstCoord.row + 1}"
+                        firstCoord.col == lastCoord.col -> "column ${firstCoord.col + 1}"
+                        else -> {
+                            val regionRow = coord.row / 3 + 1
+                            val regionCol = coord.col / 3 + 1
+                            "region ($regionRow, $regionCol)"
+                        }
+                    }
+
+                    return HintGenerator.Hint(
+                        coord = coord,
+                        value = value,
+                        technique = technique,
+                        explanation = "Value $value appears only once in $groupName. Fill it in at (${coord.row + 1}, ${coord.col + 1})!"
+                    )
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/HiddenTripleDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/HiddenTripleDetector.kt
@@ -1,0 +1,62 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.CoordGroup
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects hidden triples — three values that appear only in the same three cells within a group.
+ */
+class HiddenTripleDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.HIDDEN_TRIPLE
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coordGroup in CoordGroup.all) {
+            val valueToCells = mutableMapOf<Int, Set<Coord>>()
+            for (value in 1..9) {
+                val cells = mutableSetOf<Coord>()
+                for (coord in coordGroup.coords) {
+                    if (!board.isConfirmed(coord) && value in board.candidateValues(coord)) {
+                        cells.add(coord)
+                    }
+                }
+                if (cells.size in 2..3) {
+                    valueToCells[value] = cells
+                }
+            }
+
+            val values = valueToCells.keys.toList()
+            if (values.size < 3) continue
+            for (i in 0 until values.size - 2) {
+                for (j in i + 1 until values.size - 1) {
+                    for (k in j + 1 until values.size) {
+                        val v1 = values[i]
+                        val v2 = values[j]
+                        val v3 = values[k]
+                        val union = valueToCells[v1]!! + valueToCells[v2]!! + valueToCells[v3]!!
+
+                        if (union.size == 3) {
+                            val cells = union.toList()
+                            for (cell in cells) {
+                                val extraCandidates = board.candidateValues(cell).filter { it != v1 && it != v2 && it != v3 }
+                                if (extraCandidates.isNotEmpty()) {
+                                    return HintGenerator.Hint(
+                                        coord = cell,
+                                        value = extraCandidates.first(),
+                                        technique = technique,
+                                        explanation = "Values $v1, $v2, and $v3 form a hidden triple. " +
+                                                "Other candidates can be eliminated from these cells."
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/NakedPairDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/NakedPairDetector.kt
@@ -1,0 +1,44 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.CoordGroup
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects naked pairs — two cells in a group with the same two candidates.
+ */
+class NakedPairDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.NAKED_PAIR
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coordGroup in CoordGroup.all) {
+            val pairCells = coordGroup.coords.filter { coord ->
+                !board.isConfirmed(coord) && board.candidatePattern(coord).countOneBits() == 2
+            }
+
+            for (i in pairCells.indices) {
+                for (j in i + 1 until pairCells.size) {
+                    val coord1 = pairCells[i]
+                    val coord2 = pairCells[j]
+                    val candidates1 = board.candidateValues(coord1).toSet()
+                    val candidates2 = board.candidateValues(coord2).toSet()
+
+                    if (candidates1 == candidates2 && candidates1.size == 2) {
+                        val values = candidates1.toList()
+                        return HintGenerator.Hint(
+                            coord = coord1,
+                            value = values[0],
+                            technique = technique,
+                            explanation = "Cells (${coord1.row + 1},${coord1.col + 1}) and (${coord2.row + 1},${coord2.col + 1}) " +
+                                    "form a naked pair with values ${values[0]} and ${values[1]}. " +
+                                    "These values can be eliminated from other cells in this group."
+                        )
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/NakedSingleDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/NakedSingleDetector.kt
@@ -1,0 +1,46 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects naked singles — cells with only one remaining candidate.
+ */
+class NakedSingleDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.NAKED_SINGLE
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coord in Coord.all) {
+            if (board.isConfirmed(coord)) continue
+            val candidates = board.candidateValues(coord)
+            if (candidates.size == 1) {
+                val value = candidates.first()
+                val seen = mutableSetOf<Int>()
+                for (i in 0..8) {
+                    seen.add(board.value(Coord(coord.row, i)))
+                    seen.add(board.value(Coord(i, coord.col)))
+                }
+                val boxRow = coord.row / 3 * 3
+                val boxCol = coord.col / 3 * 3
+                for (r in boxRow until boxRow + 3) {
+                    for (c in boxCol until boxCol + 3) {
+                        seen.add(board.value(Coord(r, c)))
+                    }
+                }
+                seen.remove(0)
+                return HintGenerator.Hint(
+                    coord = coord,
+                    value = value,
+                    technique = technique,
+                    explanation = "Cell (${coord.row + 1}, ${coord.col + 1}) can only be $value! " +
+                            "All other numbers ${(1..9).filter { it != value && it !in seen }.joinToString(", ")} " +
+                            "are already present in the row, column, or box."
+                )
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/NakedTripleDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/NakedTripleDetector.kt
@@ -1,0 +1,54 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.CoordGroup
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects naked triples — three cells in a group whose candidates are a subset of three values.
+ */
+class NakedTripleDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.NAKED_TRIPLE
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (coordGroup in CoordGroup.all) {
+            val unresolved = coordGroup.coords.filter { !board.isConfirmed(it) && board.candidatePattern(it).countOneBits() in 2..3 }
+
+            if (unresolved.size < 3) continue
+
+            for (i in 0 until unresolved.size - 2) {
+                for (j in i + 1 until unresolved.size - 1) {
+                    for (k in j + 1 until unresolved.size) {
+                        val candidates1 = board.candidateValues(unresolved[i]).toSet()
+                        val candidates2 = board.candidateValues(unresolved[j]).toSet()
+                        val candidates3 = board.candidateValues(unresolved[k]).toSet()
+                        val union = candidates1 + candidates2 + candidates3
+
+                        if (union.size == 3) {
+                            for (other in unresolved) {
+                                if (other == unresolved[i] || other == unresolved[j] || other == unresolved[k]) continue
+                                val otherCandidates = board.candidateValues(other).toSet()
+                                val overlap = otherCandidates.intersect(union)
+                                if (overlap.isNotEmpty()) {
+                                    return HintGenerator.Hint(
+                                        coord = other,
+                                        value = overlap.first(),
+                                        technique = technique,
+                                        explanation = "Cells (${unresolved[i].row + 1},${unresolved[i].col + 1}), " +
+                                                "(${unresolved[j].row + 1},${unresolved[j].col + 1}), and " +
+                                                "(${unresolved[k].row + 1},${unresolved[k].col + 1}) " +
+                                                "form a naked triple. " +
+                                                "Eliminate these values from other cells in this group."
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/PointingPairDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/PointingPairDetector.kt
@@ -1,0 +1,79 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects pointing pairs — candidates restricted to one row/col within a box.
+ */
+class PointingPairDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.POINTING_PAIR
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (boxRow in 0..2) {
+            for (boxCol in 0..2) {
+                for (value in 1..9) {
+                    val cells = mutableListOf<Coord>()
+                    for (r in boxRow * 3 until (boxRow + 1) * 3) {
+                        for (c in boxCol * 3 until (boxCol + 1) * 3) {
+                            val coord = Coord(r, c)
+                            if (!board.isConfirmed(coord) &&
+                                value in board.candidateValues(coord)
+                            ) {
+                                cells.add(coord)
+                            }
+                        }
+                    }
+                    if (cells.size in 2..3) {
+                        // Check if all cells are in the same row
+                        val rows = cells.map { it.row }.toSet()
+                        if (rows.size == 1) {
+                            val row = rows.first()
+                            for (col in 0..8) {
+                                if (col / 3 == boxCol) continue
+                                val coord = Coord(row, col)
+                                if (!board.isConfirmed(coord) &&
+                                    value in board.candidateValues(coord)
+                                ) {
+                                    return HintGenerator.Hint(
+                                        coord = coord,
+                                        value = value,
+                                        technique = technique,
+                                        explanation = "Value $value in box (${boxRow + 1},${boxCol + 1}) " +
+                                                "is restricted to row ${row + 1}. " +
+                                                "Eliminate $value from row ${row + 1} in other boxes."
+                                    )
+                                }
+                            }
+                        }
+                        // Check if all cells are in the same column
+                        val cols = cells.map { it.col }.toSet()
+                        if (cols.size == 1) {
+                            val col = cols.first()
+                            for (row in 0..8) {
+                                if (row / 3 == boxRow) continue
+                                val coord = Coord(row, col)
+                                if (!board.isConfirmed(coord) &&
+                                    value in board.candidateValues(coord)
+                                ) {
+                                    return HintGenerator.Hint(
+                                        coord = coord,
+                                        value = value,
+                                        technique = technique,
+                                        explanation = "Value $value in box (${boxRow + 1},${boxCol + 1}) " +
+                                                "is restricted to column ${col + 1}. " +
+                                                "Eliminate $value from column ${col + 1} in other boxes."
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/SwordfishDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/SwordfishDetector.kt
@@ -1,0 +1,103 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects Swordfish patterns — extension of X-Wing to 3 rows/columns.
+ */
+class SwordfishDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.SWORDFISH
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+
+            // Row-based Swordfish
+            val rowToColumns = mutableMapOf<Int, Set<Int>>()
+            for (row in 0..8) {
+                val columns = mutableSetOf<Int>()
+                for (col in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0) {
+                        columns.add(col)
+                    }
+                }
+                if (columns.size in 2..3) {
+                    rowToColumns[row] = columns
+                }
+            }
+
+            val rows = rowToColumns.keys.toList()
+            for (i in 0 until rows.size - 2) {
+                for (j in i + 1 until rows.size - 1) {
+                    for (k in j + 1 until rows.size) {
+                        val row1 = rows[i]
+                        val row2 = rows[j]
+                        val row3 = rows[k]
+                        val cols1 = rowToColumns[row1]!!
+                        val cols2 = rowToColumns[row2]!!
+                        val cols3 = rowToColumns[row3]!!
+
+                        if (cols1 == cols2 && cols2 == cols3) {
+                            val swordfishCols = cols1.toList()
+                            return HintGenerator.Hint(
+                                coord = Coord(row1, swordfishCols[0]),
+                                value = value,
+                                technique = technique,
+                                explanation = "Swordfish found! Value $value in rows ${row1 + 1}, ${row2 + 1}, ${row3 + 1} " +
+                                        "appears only in columns ${swordfishCols.joinToString { (it + 1).toString() }}. " +
+                                        "Eliminate $value from these columns in other rows."
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Column-based Swordfish
+            val colToRows = mutableMapOf<Int, Set<Int>>()
+            for (col in 0..8) {
+                val rowsSet = mutableSetOf<Int>()
+                for (row in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0) {
+                        rowsSet.add(row)
+                    }
+                }
+                if (rowsSet.size in 2..3) {
+                    colToRows[col] = rowsSet
+                }
+            }
+
+            val cols = colToRows.keys.toList()
+            for (i in 0 until cols.size - 2) {
+                for (j in i + 1 until cols.size - 1) {
+                    for (k in j + 1 until cols.size) {
+                        val col1 = cols[i]
+                        val col2 = cols[j]
+                        val col3 = cols[k]
+                        val rows1 = colToRows[col1]!!
+                        val rows2 = colToRows[col2]!!
+                        val rows3 = colToRows[col3]!!
+
+                        if (rows1 == rows2 && rows2 == rows3) {
+                            val swordfishRows = rows1.toList()
+                            return HintGenerator.Hint(
+                                coord = Coord(swordfishRows[0], col1),
+                                value = value,
+                                technique = technique,
+                                explanation = "Swordfish found! Value $value in columns ${col1 + 1}, ${col2 + 1}, ${col3 + 1} " +
+                                        "appears only in rows ${swordfishRows.joinToString { (it + 1).toString() }}. " +
+                                        "Eliminate $value from these rows in other columns."
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/XWingDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/XWingDetector.kt
@@ -1,0 +1,53 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects X-Wing patterns — candidate in 2 rows restricted to same 2 columns (or vice versa).
+ */
+class XWingDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.X_WING
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+
+            val rowToColumns = mutableMapOf<Int, Set<Int>>()
+            for (row in 0..8) {
+                val columns = mutableSetOf<Int>()
+                for (col in 0..8) {
+                    val coord = Coord(row, col)
+                    if (!board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0) {
+                        columns.add(col)
+                    }
+                }
+                if (columns.size == 2) {
+                    rowToColumns[row] = columns
+                }
+            }
+
+            for ((row1, cols1) in rowToColumns) {
+                for ((row2, cols2) in rowToColumns) {
+                    if (row1 >= row2) continue
+                    if (cols1 != cols2) continue
+
+                    val cols = cols1.toList()
+                    return HintGenerator.Hint(
+                        coord = Coord(row1, cols[0]),
+                        value = value,
+                        technique = technique,
+                        explanation = "X-Wing found! Value $value appears in rows ${row1 + 1} and ${row2 + 1} " +
+                                "only in columns ${cols[0] + 1} and ${cols[1] + 1}. " +
+                                "This value can be eliminated from these columns in other rows."
+                    )
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/XYWingDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/XYWingDetector.kt
@@ -1,0 +1,70 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects XY-Wing patterns — pivot {X,Y}, Wing1 {X,Z}, Wing2 {Y,Z}, eliminate Z from cells seeing both wings.
+ */
+class XYWingDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.XY_WING
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        val biValueCells = Coord.all.filter { coord ->
+            !board.isConfirmed(coord) && board.candidatePattern(coord).countOneBits() == 2
+        }
+
+        for (pivot in biValueCells) {
+            val pivotCandidates = board.candidateValues(pivot).toList()
+            if (pivotCandidates.size != 2) continue
+            val x = pivotCandidates[0]
+            val y = pivotCandidates[1]
+
+            val wingCells = biValueCells.filter { wing ->
+                wing != pivot && CoordUtils.seesEachOther(wing, pivot)
+            }
+
+            for (wing1 in wingCells) {
+                val w1Candidates = board.candidateValues(wing1).toSet()
+                if (w1Candidates.size != 2) continue
+
+                val shared1 = if (x in w1Candidates) x else if (y in w1Candidates) y else null
+                if (shared1 == null) continue
+                val z1 = w1Candidates.find { it != shared1 } ?: continue
+
+                for (wing2 in wingCells) {
+                    if (wing2 == wing1) continue
+                    val w2Candidates = board.candidateValues(wing2).toSet()
+                    if (w2Candidates.size != 2) continue
+
+                    val shared2 = if (x in w2Candidates) x else if (y in w2Candidates) y else null
+                    if (shared2 == null || shared2 == shared1) continue
+                    val z2 = w2Candidates.find { it != shared2 } ?: continue
+
+                    if (z1 != z2) continue
+
+                    for (coord in Coord.all) {
+                        if (coord == pivot || coord == wing1 || coord == wing2) continue
+                        if (board.isConfirmed(coord)) continue
+                        if (!CoordUtils.seesEachOther(coord, wing1) || !CoordUtils.seesEachOther(coord, wing2)) continue
+                        if (z1 in board.candidateValues(coord)) {
+                            return HintGenerator.Hint(
+                                coord = coord,
+                                value = z1,
+                                technique = technique,
+                                explanation = "XY-Wing found! Pivot (${pivot.row + 1},${pivot.col + 1}) " +
+                                        "has {$x,$y}, Wing1 (${wing1.row + 1},${wing1.col + 1}) " +
+                                        "has {$shared1,$z1}, Wing2 (${wing2.row + 1},${wing2.col + 1}) " +
+                                        "has {$shared2,$z1}. Eliminate $z1 from cells seeing both wings."
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/detectors/XYZWingDetector.kt
+++ b/solver/src/main/java/will/sudoku/solver/detectors/XYZWingDetector.kt
@@ -1,0 +1,69 @@
+package will.sudoku.solver.detectors
+
+import will.sudoku.solver.Board
+import will.sudoku.solver.Coord
+import will.sudoku.solver.HintGenerator
+import will.sudoku.solver.TechniqueDetector
+
+/**
+ * Detects XYZ-Wing patterns — pivot {X,Y,Z}, Wing1 {X,Z}, Wing2 {Y,Z}, eliminate Z from cells seeing all three.
+ */
+class XYZWingDetector : TechniqueDetector {
+
+    override val technique = HintGenerator.Technique.XYZ_WING
+
+    override fun detect(board: Board): HintGenerator.Hint? {
+        val triValueCells = Coord.all.filter { coord ->
+            !board.isConfirmed(coord) && board.candidatePattern(coord).countOneBits() == 3
+        }
+
+        for (pivot in triValueCells) {
+            val pivotCands = board.candidateValues(pivot).toSet()
+            if (pivotCands.size != 3) continue
+
+            val wings = Coord.all.filter { coord ->
+                coord != pivot &&
+                        !board.isConfirmed(coord) &&
+                        board.candidatePattern(coord).countOneBits() == 2 &&
+                        CoordUtils.seesEachOther(coord, pivot)
+            }
+
+            for (wing1 in wings) {
+                val w1Cands = board.candidateValues(wing1).toSet()
+                if (pivotCands.containsAll(w1Cands)) continue
+
+                for (wing2 in wings) {
+                    if (wing2 == wing1) continue
+                    val w2Cands = board.candidateValues(wing2).toSet()
+                    if (pivotCands.containsAll(w2Cands)) continue
+
+                    val zCandidates = w1Cands.intersect(w2Cands)
+                    for (z in zCandidates) {
+                        if (z !in pivotCands) continue
+                        if (w1Cands + w2Cands != pivotCands) continue
+
+                        for (coord in Coord.all) {
+                            if (coord == pivot || coord == wing1 || coord == wing2) continue
+                            if (board.isConfirmed(coord)) continue
+                            if (!CoordUtils.seesEachOther(coord, pivot)) continue
+                            if (!CoordUtils.seesEachOther(coord, wing1)) continue
+                            if (!CoordUtils.seesEachOther(coord, wing2)) continue
+                            if (z in board.candidateValues(coord)) {
+                                return HintGenerator.Hint(
+                                    coord = coord,
+                                    value = z,
+                                    technique = technique,
+                                    explanation = "XYZ-Wing found! Pivot (${pivot.row + 1},${pivot.col + 1}) " +
+                                            "has {$pivotCands}, Wing1 (${wing1.row + 1},${wing1.col + 1}) " +
+                                            "has {$w1Cands}, Wing2 (${wing2.row + 1},${wing2.col + 1}) " +
+                                            "has {$w2Cands}. Eliminate $z from cells seeing all three."
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}


### PR DESCRIPTION
Refs #668 (part 1/3)

## Changes
- Created `TechniqueDetector` interface with `detect(board): Hint?` method
- Extracted 4 simple detectors into `detectors/` package:
  - `NakedSingleDetector` — cells with one candidate
  - `HiddenSingleDetector` — values appearing once in a group
  - `PointingPairDetector` — candidates restricted to one row/col in a box
  - `BoxLineReductionDetector` — candidates restricted to one box in a row/col
- HintGenerator now delegates to detectors for these 4 techniques
- Complex techniques (pairs, triples, wings, fish) remain in HintGenerator for follow-up PRs

## Motivation
HintGenerator is 1208 LOC with 30+ methods. This establishes the `TechniqueDetector` pattern for full decomposition. Each detector is a focused, testable class (< 100 LOC).

## Testing
- [x] All 323 tests pass
- [x] Frontend lint passes
- [x] Frontend builds
- [x] Backend builds

## Next Steps
- PR 2: Extract naked pair/triple, hidden pair/triple detectors
- PR 3: Extract X-Wing, Swordfish, XY-Wing, XYZ-Wing detectors