### PR TITLE
feat: port 5 TS eliminators to Kotlin

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
@@ -1,0 +1,75 @@
+package will.sudoku.solver
+
+/**
+ * Claiming Candidate Eliminator
+ *
+ * When a candidate value in a row or column is confined to a single box,
+ * that value can be eliminated from other cells in that box outside the row/column.
+ */
+class ClaimingCandidateEliminator : CandidateEliminator {
+
+    override val displayName = "Claiming"
+
+    override fun eliminate(board: Board): Boolean {
+        var anyUpdate = false
+        var stable: Boolean
+        do {
+            stable = true
+            for (i in 0..8) {
+                if (eliminateFromRow(board, i)) { anyUpdate = true; stable = false }
+                if (eliminateFromCol(board, i)) { anyUpdate = true; stable = false }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private fun eliminateFromRow(board: Board, row: Int): Boolean {
+        var anyUpdate = false
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+            val cellsWithCandidate = (0..8).filter { col ->
+                (board.candidatePattern(Coord(row, col)) and mask) != 0
+            }
+            if (cellsWithCandidate.size < 2) continue
+
+            val firstBox = cellsWithCandidate[0] / 3
+            if (cellsWithCandidate.all { it / 3 == firstBox }) {
+                val boxRow = row / 3
+                val colStart = firstBox * 3
+                for (r in boxRow * 3 until boxRow * 3 + 3) {
+                    if (r == row) continue
+                    for (c in colStart until colStart + 3) {
+                        val cell = Coord(r, c)
+                        if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+
+    private fun eliminateFromCol(board: Board, col: Int): Boolean {
+        var anyUpdate = false
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+            val cellsWithCandidate = (0..8).filter { row ->
+                (board.candidatePattern(Coord(row, col)) and mask) != 0
+            }
+            if (cellsWithCandidate.size < 2) continue
+
+            val firstBox = cellsWithCandidate[0] / 3
+            if (cellsWithCandidate.all { it / 3 == firstBox }) {
+                val boxCol = col / 3
+                val rowStart = firstBox * 3
+                for (r in rowStart until rowStart + 3) {
+                    for (c in boxCol * 3 until boxCol * 3 + 3) {
+                        if (c == col) continue
+                        val cell = Coord(r, c)
+                        if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
@@ -1,0 +1,123 @@
+package will.sudoku.solver
+
+/**
+ * Empty Rectangle Candidate Eliminator
+ *
+ * In a 3x3 box, if a candidate's cells form an L-shape (confined to
+ * specific rows and columns), find a strong link outside the box that
+ * intersects and eliminate the candidate from the chain's remote intersection.
+ */
+class EmptyRectangleCandidateEliminator : CandidateEliminator {
+
+    override val displayName = "Empty Rectangle"
+
+    override fun eliminate(board: Board): Boolean {
+        var anyUpdate = false
+        var stable: Boolean
+        do {
+            stable = true
+            for (value in 1..9) {
+                if (eliminateValue(board, value)) {
+                    anyUpdate = true
+                    stable = false
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private fun eliminateValue(board: Board, value: Int): Boolean {
+        val mask = Board.masks[value - 1]
+        var anyUpdate = false
+
+        // Build column strong links
+        val colLinks = mutableMapOf<Int, Pair<Int, Int>>()
+        for (c in 0..8) {
+            val rows = (0..8).filter { r ->
+                (board.candidatePattern(Coord(r, c)) and mask) != 0
+            }
+            if (rows.size == 2) colLinks[c] = Pair(rows[0], rows[1])
+        }
+
+        // Build row strong links
+        val rowLinks = mutableMapOf<Int, Pair<Int, Int>>()
+        for (r in 0..8) {
+            val cols = (0..8).filter { c ->
+                (board.candidatePattern(Coord(r, c)) and mask) != 0
+            }
+            if (cols.size == 2) rowLinks[r] = Pair(cols[0], cols[1])
+        }
+
+        // Iterate over all 9 boxes
+        for (boxRow in 0..2) {
+            for (boxCol in 0..2) {
+                val regionCoords = mutableListOf<Coord>()
+                for (r in boxRow * 3 until boxRow * 3 + 3) {
+                    for (c in boxCol * 3 until boxCol * 3 + 3) {
+                        regionCoords.add(Coord(r, c))
+                    }
+                }
+
+                val cells = regionCoords.filter { coord ->
+                    (board.candidatePattern(coord) and mask) != 0
+                }
+                if (cells.size < 2) continue
+
+                val candidateRows = cells.map { it.row }.toSet()
+                val candidateCols = cells.map { it.col }.toSet()
+
+                // Need L-shaped pattern: candidate occupies multiple rows AND columns
+                if (candidateRows.size < 2 || candidateCols.size < 2) continue
+
+                val regionIndex = boxRow * 3 + boxCol
+
+                for (erRow in candidateRows) {
+                    for (erCol in candidateCols) {
+                        // Check for strong link in erRow — one end must be in the box
+                        val rowLink = rowLinks[erRow]
+                        if (rowLink != null) {
+                            val (r1, r2) = rowLink
+                            val r1InBox = Coord(r1, erCol).region == regionIndex
+                            val r2InBox = Coord(r2, erCol).region == regionIndex
+                            if (r1InBox && !r2InBox) {
+                                val target = Coord(r2, erCol)
+                                if ((board.candidatePattern(target) and mask) != 0) {
+                                    board.eraseCandidateValue(target, value)
+                                    anyUpdate = true
+                                }
+                            } else if (r2InBox && !r1InBox) {
+                                val target = Coord(r1, erCol)
+                                if ((board.candidatePattern(target) and mask) != 0) {
+                                    board.eraseCandidateValue(target, value)
+                                    anyUpdate = true
+                                }
+                            }
+                        }
+
+                        // Check for strong link in erCol — one end must be in the box
+                        val colLink = colLinks[erCol]
+                        if (colLink != null) {
+                            val (c1, c2) = colLink
+                            val c1InBox = Coord(erRow, c1).region == regionIndex
+                            val c2InBox = Coord(erRow, c2).region == regionIndex
+                            if (c1InBox && !c2InBox) {
+                                val target = Coord(erRow, c2)
+                                if ((board.candidatePattern(target) and mask) != 0) {
+                                    board.eraseCandidateValue(target, value)
+                                    anyUpdate = true
+                                }
+                            } else if (c2InBox && !c1InBox) {
+                                val target = Coord(erRow, c1)
+                                if ((board.candidatePattern(target) and mask) != 0) {
+                                    board.eraseCandidateValue(target, value)
+                                    anyUpdate = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
@@ -1,0 +1,69 @@
+package will.sudoku.solver
+
+/**
+ * Pointing Candidate Eliminator
+ *
+ * When a candidate value within a box is confined to a single row or column,
+ * that value can be eliminated from other cells in that row/column outside the box.
+ */
+class PointingCandidateEliminator : CandidateEliminator {
+
+    override val displayName = "Pointing"
+
+    override fun eliminate(board: Board): Boolean {
+        var anyUpdate = false
+        var stable: Boolean
+        do {
+            stable = true
+            for (boxRow in 0..2) {
+                for (boxCol in 0..2) {
+                    if (eliminateFromBox(board, boxRow, boxCol)) {
+                        anyUpdate = true
+                        stable = false
+                    }
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private fun eliminateFromBox(board: Board, boxRow: Int, boxCol: Int): Boolean {
+        var anyUpdate = false
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+            val cellsWithCandidate = mutableListOf<Coord>()
+
+            for (r in boxRow * 3 until boxRow * 3 + 3) {
+                for (c in boxCol * 3 until boxCol * 3 + 3) {
+                    val coord = Coord(r, c)
+                    if ((board.candidatePattern(coord) and mask) != 0) {
+                        cellsWithCandidate.add(coord)
+                    }
+                }
+            }
+
+            if (cellsWithCandidate.size < 2) continue
+
+            // Check if all cells share the same row
+            val firstRow = cellsWithCandidate[0].row
+            if (cellsWithCandidate.all { it.row == firstRow }) {
+                for (col in 0..8) {
+                    if (col / 3 == boxCol) continue
+                    val cell = Coord(firstRow, col)
+                    if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                }
+            }
+
+            // Check if all cells share the same column
+            val firstCol = cellsWithCandidate[0].col
+            if (cellsWithCandidate.all { it.col == firstCol }) {
+                for (row in 0..8) {
+                    if (row / 3 == boxRow) continue
+                    val cell = Coord(row, firstCol)
+                    if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                }
+            }
+        }
+        return anyUpdate
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
@@ -1,0 +1,114 @@
+package will.sudoku.solver
+
+/**
+ * Skyscraper Candidate Eliminator
+ *
+ * A Skyscraper is an X-Wing variant where two rows each have a candidate
+ * in exactly 2 cells, sharing exactly 1 column. The candidate can be
+ * eliminated from cells that see both non-aligned ends.
+ *
+ * Pattern (rows): Rows r1 and r2 each have candidate in 2 cells.
+ * They share column sc. The non-shared columns are c1 (in r1) and c2 (in r2).
+ * Eliminate candidate from (r1, c2) and (r2, c1).
+ */
+class SkyscraperCandidateEliminator : CandidateEliminator {
+
+    override val displayName = "Skyscraper"
+
+    override fun eliminate(board: Board): Boolean {
+        var anyUpdate = false
+        var stable: Boolean
+        do {
+            stable = true
+            if (skyscraperRows(board)) { anyUpdate = true; stable = false }
+            if (skyscraperCols(board)) { anyUpdate = true; stable = false }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private fun skyscraperRows(board: Board): Boolean {
+        var anyUpdate = false
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+
+            // Find rows where candidate appears in exactly 2 cells
+            val rowPositions = mutableMapOf<Int, List<Int>>()
+            for (r in 0..8) {
+                val cols = (0..8).filter { c ->
+                    (board.candidatePattern(Coord(r, c)) and mask) != 0
+                }
+                if (cols.size == 2) rowPositions[r] = cols
+            }
+            if (rowPositions.size < 2) continue
+
+            val rows = rowPositions.keys.toList()
+            for (i in rows.indices) {
+                for (j in i + 1 until rows.size) {
+                    val r1 = rows[i]
+                    val r2 = rows[j]
+                    val cols1 = rowPositions[r1]!!
+                    val cols2 = rowPositions[r2]!!
+
+                    // Find shared column
+                    val shared = cols1.filter { it in cols2 }
+                    if (shared.size != 1) continue
+                    val sc = shared[0]
+
+                    // Non-shared columns
+                    val c1 = cols1.first { it != sc }
+                    val c2 = cols2.first { it != sc }
+
+                    // Eliminate from cells that see both non-aligned ends
+                    val targets = listOf(Coord(r1, c2), Coord(r2, c1))
+                    for (t in targets) {
+                        if (board.eraseCandidateValue(t, value)) {
+                            anyUpdate = true
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+
+    private fun skyscraperCols(board: Board): Boolean {
+        var anyUpdate = false
+        for (value in 1..9) {
+            val mask = Board.masks[value - 1]
+
+            val colPositions = mutableMapOf<Int, List<Int>>()
+            for (c in 0..8) {
+                val rows = (0..8).filter { r ->
+                    (board.candidatePattern(Coord(r, c)) and mask) != 0
+                }
+                if (rows.size == 2) colPositions[c] = rows
+            }
+            if (colPositions.size < 2) continue
+
+            val cols = colPositions.keys.toList()
+            for (i in cols.indices) {
+                for (j in i + 1 until cols.size) {
+                    val c1 = cols[i]
+                    val c2 = cols[j]
+                    val rows1 = colPositions[c1]!!
+                    val rows2 = colPositions[c2]!!
+
+                    val shared = rows1.filter { it in rows2 }
+                    if (shared.size != 1) continue
+                    val sr = shared[0]
+
+                    val r1 = rows1.first { it != sr }
+                    val r2 = rows2.first { it != sr }
+
+                    val targets = listOf(Coord(r1, c2), Coord(r2, c1))
+                    for (t in targets) {
+                        if (board.eraseCandidateValue(t, value)) {
+                            anyUpdate = true
+                        }
+                    }
+                }
+            }
+        }
+        return anyUpdate
+    }
+}

--- a/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
+++ b/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
@@ -54,6 +54,11 @@ data class SolverConfig(
             FrankenFishCandidateEliminator(),
             MutantFishCandidateEliminator()
             // DeathBlossom excluded — too slow for default set (combinatorial explosion)
+            // PointingCandidateEliminator() — TODO: investigate conflict with DeathBlossom/MutantFish tests
+            // ClaimingCandidateEliminator()
+            // SkyscraperCandidateEliminator()
+            // TwoStringKiteCandidateEliminator()
+            // EmptyRectangleCandidateEliminator()
         )
 
         /**

--- a/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
@@ -1,0 +1,96 @@
+package will.sudoku.solver
+
+/**
+ * 2-String Kite Candidate Eliminator
+ *
+ * A 2-String Kite uses a candidate that forms two strong links:
+ * one in a row and one in a column, connected through a box where
+ * the candidate appears in 2 cells (different row & column).
+ * The remote ends of the chain eliminate the candidate from their intersection.
+ */
+class TwoStringKiteCandidateEliminator : CandidateEliminator {
+
+    override val displayName = "2-String Kite"
+
+    override fun eliminate(board: Board): Boolean {
+        var anyUpdate = false
+        var stable: Boolean
+        do {
+            stable = true
+            for (value in 1..9) {
+                if (eliminateValue(board, value)) {
+                    anyUpdate = true
+                    stable = false
+                }
+            }
+        } while (!stable)
+        return anyUpdate
+    }
+
+    private fun eliminateValue(board: Board, value: Int): Boolean {
+        val mask = Board.masks[value - 1]
+
+        // Build row strong links: rows where candidate appears in exactly 2 cols
+        val rowLinks = mutableMapOf<Int, Pair<Int, Int>>()
+        for (r in 0..8) {
+            val cols = (0..8).filter { c ->
+                (board.candidatePattern(Coord(r, c)) and mask) != 0
+            }
+            if (cols.size == 2) rowLinks[r] = Pair(cols[0], cols[1])
+        }
+
+        // Build column strong links: cols where candidate appears in exactly 2 rows
+        val colLinks = mutableMapOf<Int, Pair<Int, Int>>()
+        for (c in 0..8) {
+            val rows = (0..8).filter { r ->
+                (board.candidatePattern(Coord(r, c)) and mask) != 0
+            }
+            if (rows.size == 2) colLinks[c] = Pair(rows[0], rows[1])
+        }
+
+        var anyUpdate = false
+
+        // Iterate over all 9 boxes
+        for (boxRow in 0..2) {
+            for (boxCol in 0..2) {
+                val regionCoords = mutableListOf<Coord>()
+                for (r in boxRow * 3 until boxRow * 3 + 3) {
+                    for (c in boxCol * 3 until boxCol * 3 + 3) {
+                        regionCoords.add(Coord(r, c))
+                    }
+                }
+
+                val regionCells = regionCoords.filter { coord ->
+                    (board.candidatePattern(coord) and mask) != 0
+                }
+
+                if (regionCells.size != 2) continue
+                val a = regionCells[0]
+                val b = regionCells[1]
+                if (a.row == b.row || a.col == b.col) continue
+
+                // Try: cell A forms row strong link, cell B forms col strong link
+                if (rowLinks.containsKey(a.row) && colLinks.containsKey(b.col)) {
+                    val (ac1, ac2) = rowLinks[a.row]!!
+                    val rowOtherCol = if (ac1 == a.col) ac2 else ac1
+                    val (br1, br2) = colLinks[b.col]!!
+                    val colOtherRow = if (br1 == b.row) br2 else br1
+                    val target = Coord(colOtherRow, rowOtherCol)
+                    if (board.eraseCandidateValue(target, value)) anyUpdate = true
+                }
+
+                // Try: cell A forms col strong link, cell B forms row strong link
+                if (colLinks.containsKey(a.col) && rowLinks.containsKey(b.row)) {
+                    val (ar1, ar2) = colLinks[a.col]!!
+                    val colOtherRow = if (ar1 == a.row) ar2 else ar1
+                    val (bc1, bc2) = rowLinks[b.row]!!
+                    val rowOtherCol = if (bc1 == b.col) bc2 else bc1
+                    val target = Coord(colOtherRow, rowOtherCol)
+                    if (board.eraseCandidateValue(target, value)) anyUpdate = true
+                }
+            }
+        }
+
+        return anyUpdate
+    }
+}


### PR DESCRIPTION
Ports 5 eliminators from TS solver: Pointing, Claiming, Skyscraper, 2-String Kite, Empty Rectangle. Not in default set yet — causes DeathBlossom/MutantFish test conflicts.