### PR TITLE
fix: add isConfirmed checks to 5 TS eliminators

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
@@ -28,7 +28,7 @@ class ClaimingCandidateEliminator : CandidateEliminator {
         for (value in 1..9) {
             val mask = Board.masks[value - 1]
             val cellsWithCandidate = (0..8).filter { col ->
-                (board.candidatePattern(Coord(row, col)) and mask) != 0
+                !board.isConfirmed(Coord(row, col)) && (board.candidatePattern(Coord(row, col)) and mask) != 0
             }
             if (cellsWithCandidate.size < 2) continue
 
@@ -53,7 +53,7 @@ class ClaimingCandidateEliminator : CandidateEliminator {
         for (value in 1..9) {
             val mask = Board.masks[value - 1]
             val cellsWithCandidate = (0..8).filter { row ->
-                (board.candidatePattern(Coord(row, col)) and mask) != 0
+                !board.isConfirmed(Coord(row, col)) && (board.candidatePattern(Coord(row, col)) and mask) != 0
             }
             if (cellsWithCandidate.size < 2) continue
 

--- a/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
@@ -34,7 +34,7 @@ class EmptyRectangleCandidateEliminator : CandidateEliminator {
         val colLinks = mutableMapOf<Int, Pair<Int, Int>>()
         for (c in 0..8) {
             val rows = (0..8).filter { r ->
-                (board.candidatePattern(Coord(r, c)) and mask) != 0
+                !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
             }
             if (rows.size == 2) colLinks[c] = Pair(rows[0], rows[1])
         }
@@ -43,7 +43,7 @@ class EmptyRectangleCandidateEliminator : CandidateEliminator {
         val rowLinks = mutableMapOf<Int, Pair<Int, Int>>()
         for (r in 0..8) {
             val cols = (0..8).filter { c ->
-                (board.candidatePattern(Coord(r, c)) and mask) != 0
+                !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
             }
             if (cols.size == 2) rowLinks[r] = Pair(cols[0], cols[1])
         }
@@ -59,7 +59,7 @@ class EmptyRectangleCandidateEliminator : CandidateEliminator {
                 }
 
                 val cells = regionCoords.filter { coord ->
-                    (board.candidatePattern(coord) and mask) != 0
+                    !board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0
                 }
                 if (cells.size < 2) continue
 

--- a/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
@@ -36,7 +36,7 @@ class PointingCandidateEliminator : CandidateEliminator {
             for (r in boxRow * 3 until boxRow * 3 + 3) {
                 for (c in boxCol * 3 until boxCol * 3 + 3) {
                     val coord = Coord(r, c)
-                    if ((board.candidatePattern(coord) and mask) != 0) {
+                    if (!board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0) {
                         cellsWithCandidate.add(coord)
                     }
                 }

--- a/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
@@ -35,7 +35,7 @@ class SkyscraperCandidateEliminator : CandidateEliminator {
             val rowPositions = mutableMapOf<Int, List<Int>>()
             for (r in 0..8) {
                 val cols = (0..8).filter { c ->
-                    (board.candidatePattern(Coord(r, c)) and mask) != 0
+                    !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
                 }
                 if (cols.size == 2) rowPositions[r] = cols
             }
@@ -79,7 +79,7 @@ class SkyscraperCandidateEliminator : CandidateEliminator {
             val colPositions = mutableMapOf<Int, List<Int>>()
             for (c in 0..8) {
                 val rows = (0..8).filter { r ->
-                    (board.candidatePattern(Coord(r, c)) and mask) != 0
+                    !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
                 }
                 if (rows.size == 2) colPositions[c] = rows
             }

--- a/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
@@ -34,7 +34,7 @@ class TwoStringKiteCandidateEliminator : CandidateEliminator {
         val rowLinks = mutableMapOf<Int, Pair<Int, Int>>()
         for (r in 0..8) {
             val cols = (0..8).filter { c ->
-                (board.candidatePattern(Coord(r, c)) and mask) != 0
+                !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
             }
             if (cols.size == 2) rowLinks[r] = Pair(cols[0], cols[1])
         }
@@ -43,7 +43,7 @@ class TwoStringKiteCandidateEliminator : CandidateEliminator {
         val colLinks = mutableMapOf<Int, Pair<Int, Int>>()
         for (c in 0..8) {
             val rows = (0..8).filter { r ->
-                (board.candidatePattern(Coord(r, c)) and mask) != 0
+                !board.isConfirmed(Coord(r, c)) && (board.candidatePattern(Coord(r, c)) and mask) != 0
             }
             if (rows.size == 2) colLinks[c] = Pair(rows[0], rows[1])
         }
@@ -61,7 +61,7 @@ class TwoStringKiteCandidateEliminator : CandidateEliminator {
                 }
 
                 val regionCells = regionCoords.filter { coord ->
-                    (board.candidatePattern(coord) and mask) != 0
+                    !board.isConfirmed(coord) && (board.candidatePattern(coord) and mask) != 0
                 }
 
                 if (regionCells.size != 2) continue


### PR DESCRIPTION
Addresses reviewer feedback on PR #675. Added !board.isConfirmed(coord) checks before candidatePattern in all 5 new eliminators. Matches pattern used by FishCandidateEliminator and other existing eliminators.