### PR TITLE
fix: add isConfirmed before erase in 5 TS eliminators

### DIFF
--- a/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/ClaimingCandidateEliminator.kt
@@ -40,7 +40,7 @@ class ClaimingCandidateEliminator : CandidateEliminator {
                     if (r == row) continue
                     for (c in colStart until colStart + 3) {
                         val cell = Coord(r, c)
-                        if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                        if (!board.isConfirmed(cell) && board.eraseCandidateValue(cell, value)) anyUpdate = true
                     }
                 }
             }
@@ -65,7 +65,7 @@ class ClaimingCandidateEliminator : CandidateEliminator {
                     for (c in boxCol * 3 until boxCol * 3 + 3) {
                         if (c == col) continue
                         val cell = Coord(r, c)
-                        if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                        if (!board.isConfirmed(cell) && board.eraseCandidateValue(cell, value)) anyUpdate = true
                     }
                 }
             }

--- a/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/EmptyRectangleCandidateEliminator.kt
@@ -81,13 +81,13 @@ class EmptyRectangleCandidateEliminator : CandidateEliminator {
                             val r2InBox = Coord(r2, erCol).region == regionIndex
                             if (r1InBox && !r2InBox) {
                                 val target = Coord(r2, erCol)
-                                if ((board.candidatePattern(target) and mask) != 0) {
+                                if (!board.isConfirmed(target) && (board.candidatePattern(target) and mask) != 0) {
                                     board.eraseCandidateValue(target, value)
                                     anyUpdate = true
                                 }
                             } else if (r2InBox && !r1InBox) {
                                 val target = Coord(r1, erCol)
-                                if ((board.candidatePattern(target) and mask) != 0) {
+                                if (!board.isConfirmed(target) && (board.candidatePattern(target) and mask) != 0) {
                                     board.eraseCandidateValue(target, value)
                                     anyUpdate = true
                                 }
@@ -102,13 +102,13 @@ class EmptyRectangleCandidateEliminator : CandidateEliminator {
                             val c2InBox = Coord(erRow, c2).region == regionIndex
                             if (c1InBox && !c2InBox) {
                                 val target = Coord(erRow, c2)
-                                if ((board.candidatePattern(target) and mask) != 0) {
+                                if (!board.isConfirmed(target) && (board.candidatePattern(target) and mask) != 0) {
                                     board.eraseCandidateValue(target, value)
                                     anyUpdate = true
                                 }
                             } else if (c2InBox && !c1InBox) {
                                 val target = Coord(erRow, c1)
-                                if ((board.candidatePattern(target) and mask) != 0) {
+                                if (!board.isConfirmed(target) && (board.candidatePattern(target) and mask) != 0) {
                                     board.eraseCandidateValue(target, value)
                                     anyUpdate = true
                                 }

--- a/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/PointingCandidateEliminator.kt
@@ -50,7 +50,7 @@ class PointingCandidateEliminator : CandidateEliminator {
                 for (col in 0..8) {
                     if (col / 3 == boxCol) continue
                     val cell = Coord(firstRow, col)
-                    if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                    if (!board.isConfirmed(cell) && board.eraseCandidateValue(cell, value)) anyUpdate = true
                 }
             }
 
@@ -60,7 +60,7 @@ class PointingCandidateEliminator : CandidateEliminator {
                 for (row in 0..8) {
                     if (row / 3 == boxRow) continue
                     val cell = Coord(row, firstCol)
-                    if (board.eraseCandidateValue(cell, value)) anyUpdate = true
+                    if (!board.isConfirmed(cell) && board.eraseCandidateValue(cell, value)) anyUpdate = true
                 }
             }
         }

--- a/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/SkyscraperCandidateEliminator.kt
@@ -61,7 +61,7 @@ class SkyscraperCandidateEliminator : CandidateEliminator {
                     // Eliminate from cells that see both non-aligned ends
                     val targets = listOf(Coord(r1, c2), Coord(r2, c1))
                     for (t in targets) {
-                        if (board.eraseCandidateValue(t, value)) {
+                        if (!board.isConfirmed(t) && board.eraseCandidateValue(t, value)) {
                             anyUpdate = true
                         }
                     }
@@ -102,7 +102,7 @@ class SkyscraperCandidateEliminator : CandidateEliminator {
 
                     val targets = listOf(Coord(r1, c2), Coord(r2, c1))
                     for (t in targets) {
-                        if (board.eraseCandidateValue(t, value)) {
+                        if (!board.isConfirmed(t) && board.eraseCandidateValue(t, value)) {
                             anyUpdate = true
                         }
                     }

--- a/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
+++ b/solver/src/main/java/will/sudoku/solver/SolverConfig.kt
@@ -54,11 +54,8 @@ data class SolverConfig(
             FrankenFishCandidateEliminator(),
             MutantFishCandidateEliminator()
             // DeathBlossom excluded — too slow for default set (combinatorial explosion)
-            // PointingCandidateEliminator() — TODO: investigate conflict with DeathBlossom/MutantFish tests
-            // ClaimingCandidateEliminator()
-            // SkyscraperCandidateEliminator()
-            // TwoStringKiteCandidateEliminator()
-            // EmptyRectangleCandidateEliminator()
+            // Pointing, Claiming, Skyscraper, 2-String Kite, Empty Rectangle available
+            // but cause over-elimination when combined with other eliminators.
         )
 
         /**

--- a/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
+++ b/solver/src/main/java/will/sudoku/solver/TwoStringKiteCandidateEliminator.kt
@@ -76,7 +76,7 @@ class TwoStringKiteCandidateEliminator : CandidateEliminator {
                     val (br1, br2) = colLinks[b.col]!!
                     val colOtherRow = if (br1 == b.row) br2 else br1
                     val target = Coord(colOtherRow, rowOtherCol)
-                    if (board.eraseCandidateValue(target, value)) anyUpdate = true
+                    if (!board.isConfirmed(target) && board.eraseCandidateValue(target, value)) anyUpdate = true
                 }
 
                 // Try: cell A forms col strong link, cell B forms row strong link
@@ -86,7 +86,7 @@ class TwoStringKiteCandidateEliminator : CandidateEliminator {
                     val (bc1, bc2) = rowLinks[b.row]!!
                     val rowOtherCol = if (bc1 == b.col) bc2 else bc1
                     val target = Coord(colOtherRow, rowOtherCol)
-                    if (board.eraseCandidateValue(target, value)) anyUpdate = true
+                    if (!board.isConfirmed(target) && board.eraseCandidateValue(target, value)) anyUpdate = true
                 }
             }
         }


### PR DESCRIPTION
Adds isConfirmed check before eraseCandidateValue in all 5 new eliminators (Pointing, Claiming, Skyscraper, 2-String Kite, Empty Rectangle).

Also keeps them out of defaultEliminators() — they cause over-elimination when combined with other eliminators in a loop. Available for users who want to enable them via custom SolverConfig.

Note: Root cause of the over-elimination is still under investigation. The eliminators individually work correctly, but when run in a loop with all 20 eliminators, they create contradictions.