### PR TITLE
fix: rate limiter now returns 429 after threshold (#725)

### DIFF
--- a/web/src/main/kotlin/will/sudoku/web/Application.kt
+++ b/web/src/main/kotlin/will/sudoku/web/Application.kt
@@ -54,7 +54,7 @@ fun Application.module() {
 
     // Rate limiting: 100 requests per minute per IP
     install(RateLimit) {
-        register {
+        global {
             rateLimiter(100, 1.minutes)
             requestKey { call ->
                 call.request.local.remoteAddress


### PR DESCRIPTION
Refs #725

## Changes
- Changed `register { }` to `global { }` in RateLimit plugin config in Application.kt
- `register {}` only registers a named rate limiter but never applies it to any route
- `global {}` applies the rate limiter to all routes automatically

## Root Cause
The Ktor RateLimit plugin has two methods:
- `register {}` — registers a named limiter that must be explicitly applied to routes via `rateLimit {}` blocks
- `global {}` — applies rate limiting globally to all routes

The code used `register {}` but never wrapped routes in `rateLimit {}`, so the limiter was registered but never enforced.

## Verification
- Sent 120 sequential requests to `/api/v1/health` → 100 returned 200, 20 returned 429
- `Retry-After` and `X-RateLimit-*` headers present in responses

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)
- [x] Manually verified rate limiting works (100×200, then 429)

Reference: [Ktor RateLimit docs](https://ktor.io/docs/server-rate-limit.html)
