### PR TITLE
fix: add 'P' keyboard shortcut for pencil mode toggle (#726)

### DIFF
--- a/web-ui/src/App.vue
+++ b/web-ui/src/App.vue
@@ -514,6 +514,13 @@ const handleKeyDown = (e) => {
     getHint()
     return
   }
+
+  // P for pencil mode toggle
+  if (e.key === 'p' || e.key === 'P') {
+    e.preventDefault()
+    pencilMode.value = !pencilMode.value
+    return
+  }
 }
 
 onMounted(() => {

--- a/web-ui/src/components/KeyboardHelp.vue
+++ b/web-ui/src/components/KeyboardHelp.vue
@@ -43,6 +43,8 @@ const shortcuts: Shortcut[] = [
   { key: '↑ ↓ ← →', desc: 'Navigate cells' },
   { key: '1-9', desc: 'Enter number' },
   { key: 'Delete / ⌫', desc: 'Clear cell' },
+  { key: 'P', desc: 'Toggle pencil mode' },
+  { key: 'H', desc: 'Get hint' },
   { key: 'Ctrl+Z', desc: 'Undo' },
   { key: 'Ctrl+Y', desc: 'Redo' },
   { key: '?', desc: 'Show this help' },


### PR DESCRIPTION
Refs #726

## Changes
- Added 'P'/'p' key handler in `handleKeyDown` in App.vue to toggle pencil mode
- Added 'P' and 'H' entries to the keyboard help modal in KeyboardHelp.vue

## Testing
- [x] Frontend lint passes (`npm run lint:ci`)
- [x] Frontend builds (`npm run build`)
