### PR TITLE
fix: change quiz answerValue from String to Int (#727)

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -259,13 +259,13 @@ val validateJsonData by tasks.registering {
                 error("$qId: answerCell $ac points to filled cell '${puzzle[ac]}'")
             }
 
-            val avMatch = Regex("\"answerValue\"\\s*:\\s*\"([^\"]+)\"").find(qJson)
+            val avMatch = Regex("\"answerValue\"\\s*:\\s*(\\d+)").find(qJson)
             if (avMatch == null) {
                 error("$qId: missing answerValue")
             } else {
                 val av = avMatch.groupValues[1]
                 if (av.length != 1 || av[0] !in '1'..'9') {
-                    error("$qId: answerValue='$av' is not a digit 1-9")
+                    error("$qId: answerValue=$av is not a digit 1-9")
                 }
             }
 

--- a/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
+++ b/web/src/main/kotlin/will/sudoku/web/TutorialRoutes.kt
@@ -78,7 +78,7 @@ data class QuizQuestion(
     val question: String,
     val hint: String,
     val answerCell: Int,
-    val answerValue: String,
+    val answerValue: Int,
     val explanation: String = "",
     val highlightCells: List<Int> = emptyList(),
     val highlightColor: String = "blue",

--- a/web/src/main/resources/tutorials/quizzes.json
+++ b/web/src/main/resources/tutorials/quizzes.json
@@ -13,7 +13,7 @@
         "question": "Which cell in row 5 has only ONE candidate left (a Naked Single)?",
         "hint": "Look at row 5. Find a cell where all other numbers 1-9 are already present in the row, column, or box, leaving just one possibility.",
         "answerCell": 40,
-        "answerValue": "5",
+        "answerValue": 5,
         "explanation": "Cell R5C5 is a Naked Single with value 5. Every other digit (1-9 except 5) already appears in its row (row 5), column (column 5), or 3×3 box (center box), so 5 is the only possible candidate.",
         "highlightCells": [
           36,
@@ -42,7 +42,7 @@
         "question": "Look at the bottom-middle section of the board. Which cell in row 9 has only ONE candidate left (a Naked Single)?",
         "hint": "Check R9C4 — look at which digits already appear in row 9, column 4, and box 8. Eight of the nine digits are already present.",
         "answerCell": 75,
-        "answerValue": "4",
+        "answerValue": 4,
         "explanation": "Cell R9C4 is a Naked Single with value 4. In row 9, digits 1, 3, and 5 are already placed. In column 4, digits 1, 2, 3, 6, 7, and 8 appear. In box 8, digits 1, 2, 3, 6, and 9 are present. Together, eight of the nine digits (1, 2, 3, 5, 6, 7, 8, 9) are eliminated — only 4 remains.",
         "highlightCells": [
           3,
@@ -91,7 +91,7 @@
         "question": "Where is the Hidden Single for the number 5 in row 2?",
         "hint": "Check which empty cell in row 2 is the only one that can hold the number 5. Other cells are blocked by columns or boxes already containing 5.",
         "answerCell": 14,
-        "answerValue": "5",
+        "answerValue": 5,
         "explanation": "Cell R2C6 is a Hidden Single for value 5 in row 2. Every other empty cell in row 2 is blocked from holding 5 — columns and box constraints eliminate all alternatives, leaving R2C6 as the only cell in the row where 5 can go.",
         "highlightCells": [
           9,
@@ -120,7 +120,7 @@
         "question": "Find the Hidden Single for the number 2 in column 6. Which cell?",
         "hint": "Look for a cell in column 6 where 2 can go. All other cells in that column either already have a value or are blocked by rows/boxes containing 2.",
         "answerCell": 23,
-        "answerValue": "2",
+        "answerValue": 2,
         "explanation": "Cell R3C6 is a Hidden Single for value 2 in column 6. Every other empty cell in column 6 is blocked from holding 2 by the row or box already containing that digit. R3C6 is the only cell in the column where 2 can go.",
         "highlightCells": [
           5,
@@ -159,7 +159,7 @@
         "question": "Find the Naked Pair in this puzzle. Which two cells share exactly the same two candidates in a column?",
         "hint": "Look for two cells in the same column that both have only two candidates — and they're the same two numbers.",
         "answerCell": 57,
-        "answerValue": "8",
+        "answerValue": 8,
         "explanation": "Cells R7C4 and R9C4 form a Naked Pair with candidates {1, 8}. Since these are the only two cells in column 4 that can hold 1 and 8, these values are locked to those cells and can be eliminated from other cells in the column.",
         "highlightCells": [
           57,
@@ -181,7 +181,7 @@
         "question": "Spot the Naked Pair in a row. Which cell is part of the pair?",
         "hint": "Look for two cells in the same row that can only hold the same two numbers — no other candidates are possible.",
         "answerCell": 1,
-        "answerValue": "3",
+        "answerValue": 3,
         "explanation": "Cells R1C2 and R1C3 form a Naked Pair with candidates {3, 4}. Since both cells can only contain 3 or 4, these two values are locked to those cells in the row, eliminating 3 and 4 from all other cells in that row.",
         "highlightCells": [
           1,
@@ -213,7 +213,7 @@
         "question": "Find a Pointing Pair: which cells in a box force an elimination in a row or column?",
         "hint": "When a candidate in a box is restricted to a single row or column, it eliminates that candidate from the rest of the row/column outside the box.",
         "answerCell": 27,
-        "answerValue": "8",
+        "answerValue": 8,
         "explanation": "A Pointing Pair occurs when a candidate within a 3×3 box is confined to a single row or column. This means the candidate must appear in one of those two cells in the box, so it can be eliminated from the rest of that row or column outside the box. Look for a digit that appears as a candidate in only two cells of a box, both in the same row or column.",
         "highlightCells": [
           27,
@@ -236,7 +236,7 @@
         "question": "Where can you apply Box-Line Reduction in this puzzle?",
         "hint": "Look for a row or column where a candidate is confined to a single box, allowing elimination from other cells in that box.",
         "answerCell": 0,
-        "answerValue": "4",
+        "answerValue": 4,
         "explanation": "Box-Line Reduction is the reverse of a Pointing Pair. When all instances of a candidate within a row or column fall inside a single box, that candidate can be eliminated from other cells in the box that aren't in that row or column.",
         "highlightCells": [
           0,
@@ -269,7 +269,7 @@
         "question": "Find three cells forming a Naked Triple. Which cell is part of it?",
         "hint": "Three cells that together contain only three candidates — they eliminate those candidates from other cells in the group.",
         "answerCell": 26,
-        "answerValue": "7",
+        "answerValue": 7,
         "explanation": "A Naked Triple occurs when three cells in the same row, column, or box together contain exactly three candidate values. While each cell might have 2 or 3 candidates, the union of all candidates is exactly 3 values. These values are locked to those cells and can be eliminated from other cells in the unit.",
         "highlightCells": [
           24,
@@ -292,7 +292,7 @@
         "question": "Where is the Hidden Triple in this puzzle?",
         "hint": "Three numbers that can only appear in three specific cells within a group, eliminating other candidates from those cells.",
         "answerCell": 2,
-        "answerValue": "4",
+        "answerValue": 4,
         "explanation": "A Hidden Triple occurs when three candidate values each appear in only three cells within a row, column, or box. Other candidates in those three cells can be eliminated, since those cells must hold exactly those three values between them.",
         "highlightCells": [
           0,
@@ -325,7 +325,7 @@
         "question": "In this puzzle, cell R1C2 is a Naked Single. What value goes there?",
         "hint": "An X-Wing occurs when a candidate appears in exactly two cells in two rows, and those cells align in the same two columns.",
         "answerCell": 1,
-        "answerValue": "4",
+        "answerValue": 4,
         "explanation": "Cell R1C2 (row 1, column 2) can only contain 4. After checking row 1, column 2, and box 1, all other digits are eliminated, making 4 the only possibility.",
         "highlightCells": [
           1,
@@ -347,7 +347,7 @@
         "question": "Find the Swordfish pattern. Which row contains part of the Swordfish?",
         "hint": "A Swordfish is like an X-Wing with three rows and three columns — look for a candidate appearing in exactly three cells across three rows.",
         "answerCell": 10,
-        "answerValue": "2",
+        "answerValue": 2,
         "explanation": "A Swordfish extends the X-Wing concept to three rows and three columns. When a candidate appears in exactly three cells in each of three rows, and those cells align in exactly three columns, the candidate can be eliminated from other cells in those columns.",
         "highlightCells": [
           10,
@@ -380,7 +380,7 @@
         "question": "Find the XY-Wing: which cell is the pivot of the XY-Wing?",
         "hint": "An XY-Wing has a pivot cell with two candidates, and two wing cells that each share one candidate with the pivot.",
         "answerCell": 0,
-        "answerValue": "7",
+        "answerValue": 7,
         "explanation": "An XY-Wing uses three cells: a pivot with candidates XY, and two wings with candidates XZ and YZ respectively. The shared candidate Z can be eliminated from any cell that sees both wings, because one of the wings must hold Z.",
         "highlightCells": [
           0
@@ -401,7 +401,7 @@
         "question": "Where can you spot an XY-Wing or XYZ-Wing elimination?",
         "hint": "Look for three cells with specific candidate overlaps: a pivot cell and two wing cells sharing candidates.",
         "answerCell": 18,
-        "answerValue": "8",
+        "answerValue": 8,
         "explanation": "The XYZ-Wing is a variant where the pivot cell has three candidates (XYZ) and two wings have two candidates each (XZ and YZ). The candidate Z common to all three cells can be eliminated from any cell that sees all three.",
         "highlightCells": [
           18,
@@ -433,7 +433,7 @@
         "question": "Find the W-Wing pattern in this puzzle. Which cell has its candidates determined by the W-Wing?",
         "hint": "A W-Wing uses two bivalue cells with the same candidates connected by a conjugate pair in a row, column, or box.",
         "answerCell": 36,
-        "answerValue": "3",
+        "answerValue": 3,
         "explanation": "A W-Wing occurs when two cells (the wings) contain the same two candidates and are connected by a strong link on one of those candidates. The other candidate can be eliminated from any cell that sees both wings, which helps determine values in the connected cells.",
         "highlightCells": [
           36,
@@ -456,7 +456,7 @@
         "question": "Where can you apply a W-Wing elimination to narrow down candidates?",
         "hint": "Look for two bivalue cells with the same candidates connected by a strong link in a column.",
         "answerCell": 8,
-        "answerValue": "2",
+        "answerValue": 2,
         "explanation": "Cells R1C8 and R5C9 are both bivalue cells with candidates {1, 2}. They are connected by a strong link on 1 in column 8 — only R1C8 and R4C8 can hold 1 in that column. Since one of the wings must be 1 (or else the strong link forces it), one of them must be 2. Therefore, 2 can be eliminated from R1C9, which sees both wings.",
         "highlightCells": [
           7,
@@ -489,7 +489,7 @@
         "question": "Find the Unique Rectangle pattern. Which cell is part of the deadly pattern?",
         "hint": "A Unique Rectangle occurs when four cells form a rectangle with the same two candidates — this would create multiple solutions.",
         "answerCell": 40,
-        "answerValue": "3",
+        "answerValue": 3,
         "explanation": "A Unique Rectangle exploits the fact that valid Sudoku puzzles have exactly one solution. When four cells at the corners of a rectangle share the same two candidates, one of those candidates must be eliminated to avoid creating two valid solutions.",
         "highlightCells": [
           40
@@ -510,7 +510,7 @@
         "question": "Where can Simple Coloring eliminate a candidate?",
         "hint": "Color pairs of the same candidate to find a contradiction that eliminates one color.",
         "answerCell": 2,
-        "answerValue": "8",
+        "answerValue": 8,
         "explanation": "Simple Coloring chains pairs of a single candidate through the grid. By alternating two colors along the chain, if both colors appear in the same row, column, or box, we can eliminate all candidates of one color since that would create a contradiction.",
         "highlightCells": [
           2
@@ -541,7 +541,7 @@
         "question": "Which advanced technique (ALS-XZ, Death Blossom, Forcing Chains) applies here?",
         "hint": "Look for Almost Locked Sets that interact through a restricted common candidate.",
         "answerCell": 40,
-        "answerValue": "4",
+        "answerValue": 4,
         "explanation": "Cell R5C5 can be determined using ALS-XZ (Almost Locked Set elimination). Two Almost Locked Sets share a restricted common candidate, and the interaction eliminates all but one possibility at R5C5, giving value 4. This technique requires identifying sets of cells that are one candidate short of being a locked set.",
         "highlightCells": [
           40
@@ -562,7 +562,7 @@
         "question": "Find the cell that can only be determined through advanced elimination techniques.",
         "hint": "Look for cells where multiple candidates remain after basic techniques are exhausted.",
         "answerCell": 0,
-        "answerValue": "2",
+        "answerValue": 2,
         "explanation": "Cell R1C1 requires advanced techniques to solve. After all basic eliminations (naked/hidden singles, pairs, pointing pairs, etc.), this cell still has multiple candidates and needs techniques like Forcing Chains or Death Blossom to determine its value.",
         "highlightCells": [
           0

--- a/web/src/test/kotlin/will/sudoku/web/QuizDataValidationTest.kt
+++ b/web/src/test/kotlin/will/sudoku/web/QuizDataValidationTest.kt
@@ -12,7 +12,7 @@ data class QuizQuestion(
     val question: String,
     val hint: String,
     val answerCell: Int,
-    val answerValue: String,
+    val answerValue: Int,
     val highlightCells: List<Int>,
     val highlightColor: String
 )

--- a/web/src/test/kotlin/will/sudoku/web/TutorialQuizValidationTest.kt
+++ b/web/src/test/kotlin/will/sudoku/web/TutorialQuizValidationTest.kt
@@ -83,11 +83,7 @@ class TutorialQuizValidationTest {
 
         for (quiz in quizzes) {
             for (q in quiz.questions) {
-                val answerVal = q.answerValue.toIntOrNull()
-                if (answerVal == null) {
-                    violations.add("${q.id}: answerValue '${q.answerValue}' is not a number")
-                    continue
-                }
+                val answerVal = q.answerValue
 
                 val board = helper.prepareBoardBasic(q.puzzle)
                 val candidates = helper.getCandidates(board, q.answerCell)

--- a/web/src/test/kotlin/will/sudoku/web/TutorialTestHelper.kt
+++ b/web/src/test/kotlin/will/sudoku/web/TutorialTestHelper.kt
@@ -45,7 +45,7 @@ object TutorialTestHelper {
         val question: String = "",
         val hint: String = "",
         val answerCell: Int,
-        val answerValue: String,
+        val answerValue: Int,
         val explanation: String = "",
         val highlightCells: List<Int> = emptyList(),
         val highlightColor: String = "blue",


### PR DESCRIPTION
Refs #727

## Changes
- Changed `QuizQuestion.answerValue` type from `String` to `Int` in TutorialRoutes.kt
- Updated all 20 values in `quizzes.json` from string to integer (e.g. `"5"` → `5`)
- Updated test data classes in TutorialTestHelper.kt and QuizDataValidationTest.kt
- Simplified test in TutorialQuizValidationTest.kt (removed unnecessary `.toIntOrNull()`)

## Notes
- `TutorialStep.answerValue` remains `String?` — it's a separate field for lesson steps, not affected by this bug
- Frontend does not reference quiz `answerValue` — no frontend changes needed

## Verification
- API now returns `"answerValue": 5` (integer) instead of `"answerValue": "5"` (string)
- Verified via `curl GET /api/v1/tutorials/quizzes`

## Testing
- [x] All tests pass (`./gradlew test`)
- [x] Frontend builds (`npm run build`)
- [x] Backend builds (`./gradlew :web:installDist`)
- [x] Manually verified API response type change
