### PR TITLE
test: add game state save/restore tests (#710)

### DIFF
--- a/web-ui/tests/gameStateSaveRestore.test.ts
+++ b/web-ui/tests/gameStateSaveRestore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Game State Save/Restore Tests
+ *
+ * Verifies that the game state save/restore logic in App.vue:
+ * 1. Stores all required fields (puzzle, playMode, difficulty, timestamp)
+ * 2. Handles missing data gracefully (try/catch)
+ * 3. Handles malformed JSON without crashing
+ * 4. Validates puzzle length is 81
+ *
+ * Uses static analysis (source code scanning) since the save/restore
+ * logic is embedded in App.vue's onMounted hook.
+ *
+ * Refs #710
+ */
+
+const APP_VUE = readFileSync(join(__dirname, '..', 'src', 'App.vue'), 'utf-8')
+
+describe('Game state save/restore', () => {
+  describe('save path (localStorage.setItem)', () => {
+    it('saves to sudoku-current-game key', () => {
+      expect(APP_VUE).toMatch(/localStorage\.setItem\(\s*['"]sudoku-current-game['"]/)
+    })
+
+    it('stores puzzle field', () => {
+      // The setItem call should include puzzle in the JSON
+      const saveMatch = APP_VUE.match(/localStorage\.setItem\(\s*['"]sudoku-current-game['"]\s*,\s*JSON\.stringify\(\s*\{([^}]+)\}/s)
+      expect(saveMatch).not.toBeNull()
+      expect(saveMatch![1]).toMatch(/\bpuzzle\b/)
+    })
+
+    it('stores playMode field', () => {
+      const saveMatch = APP_VUE.match(/localStorage\.setItem\(\s*['"]sudoku-current-game['"]\s*,\s*JSON\.stringify\(\s*\{([^}]+)\}/s)
+      expect(saveMatch).not.toBeNull()
+      expect(saveMatch![1]).toMatch(/\bplayMode\b/)
+    })
+
+    it('stores difficulty field', () => {
+      const saveMatch = APP_VUE.match(/localStorage\.setItem\(\s*['"]sudoku-current-game['"]\s*,\s*JSON\.stringify\(\s*\{([^}]+)\}/s)
+      expect(saveMatch).not.toBeNull()
+      expect(saveMatch![1]).toMatch(/\bdifficulty\b/)
+    })
+
+    it('stores timestamp field', () => {
+      const saveMatch = APP_VUE.match(/localStorage\.setItem\(\s*['"]sudoku-current-game['"]\s*,\s*JSON\.stringify\(\s*\{([^}]+)\}/s)
+      expect(saveMatch).not.toBeNull()
+      // Check for ts or timestamp
+      expect(saveMatch![1]).toMatch(/\b(ts|timestamp)\b/)
+    })
+  })
+
+  describe('restore path (localStorage.getItem)', () => {
+    it('reads from sudoku-current-game key', () => {
+      expect(APP_VUE).toMatch(/localStorage\.getItem\(\s*['"]sudoku-current-game['"]/)
+    })
+
+    it('wraps restore in try/catch for error handling', () => {
+      // Find the getItem call and verify there's a try/catch around it
+      const getItemIdx = APP_VUE.indexOf("localStorage.getItem('sudoku-current-game')")
+      expect(getItemIdx).toBeGreaterThan(-1)
+
+      // Look for try/catch within 500 chars after getItem
+      const afterGetItem = APP_VUE.slice(getItemIdx, getItemIdx + 500)
+      expect(afterGetItem).toMatch(/try\s*\{/)
+      expect(afterGetItem).toMatch(/catch/)
+    })
+
+    it('handles malformed JSON gracefully (catch block is empty or logs)', () => {
+      // The catch block should not re-throw or crash
+      const getItemIdx = APP_VUE.indexOf("localStorage.getItem('sudoku-current-game')")
+      const afterGetItem = APP_VUE.slice(getItemIdx, getItemIdx + 500)
+      // Match catch (e) {} or catch (e) { // ... } without throw
+      const catchMatch = afterGetItem.match(/catch\s*\([^)]*\)\s*\{([^}]*)\}/)
+      expect(catchMatch).not.toBeNull()
+      // Ensure the catch block doesn't contain 'throw'
+      expect(catchMatch![1]).not.toMatch(/\bthrow\b/)
+    })
+
+    it('validates puzzle length is 81 on restore', () => {
+      const getItemIdx = APP_VUE.indexOf("localStorage.getItem('sudoku-current-game')")
+      const afterGetItem = APP_VUE.slice(getItemIdx, getItemIdx + 500)
+      expect(afterGetItem).toMatch(/puzzle\.length\s*===?\s*81|length\s*===?\s*81/)
+    })
+
+    it('does not restore empty puzzle (all dots or all zeros)', () => {
+      const getItemIdx = APP_VUE.indexOf("localStorage.getItem('sudoku-current-game')")
+      const afterGetItem = APP_VUE.slice(getItemIdx, getItemIdx + 500)
+      // Should check puzzle is not all dots/zeros
+      expect(afterGetItem).toMatch(/\.\s*repeat\(81\)|'0'\s*\*\s*81/)
+    })
+  })
+})


### PR DESCRIPTION
Refs #710

## Changes
- Added `tests/gameStateSaveRestore.test.ts` — 10 static analysis tests verifying game state save/restore in App.vue

## Tests Cover
**Save path:**
- Stores to `sudoku-current-game` key
- Includes puzzle, playMode, difficulty, and timestamp fields

**Restore path:**
- Reads from `sudoku-current-game` key
- Wraps restore in try/catch (graceful error handling)
- Catch block does not re-throw (handles malformed JSON)
- Validates puzzle length === 81
- Rejects empty puzzle (all dots)

## Testing
- [x] All 10 tests pass (`npx vitest run tests/gameStateSaveRestore.test.ts`)
- [x] No frontend source changes (test-only)

## Self-Review
- [x] PR description matches actual diff (1 file, 95 lines)
- [x] No unrelated changes
- [x] No docs needed (test-only change)
