### PR TITLE
test: add NumberBar + highlight priority + tutorial highlights + themes audit (#707, #708)

### DIFF
--- a/web-ui/tests/numberBarHighlightPriority.test.ts
+++ b/web-ui/tests/numberBarHighlightPriority.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * NumberBar + Highlight Priority Audit
+ *
+ * Verifies:
+ * - NumberBar.vue: remaining count display, digit disabling at count >= 9,
+ *   progress bar width reflects count
+ * - SudokuGrid.vue: CSS class application priority — selected cell gets
+ *   highest priority, same-value and peer highlighting only when not selected
+ *
+ * Refs #707
+ */
+
+const NUMBER_BAR = readFileSync(
+  join(__dirname, '..', 'src', 'components', 'NumberBar.vue'),
+  'utf-8',
+)
+const SUDOKU_GRID = readFileSync(
+  join(__dirname, '..', 'src', 'components', 'SudokuGrid.vue'),
+  'utf-8',
+)
+
+describe('NumberBar — remaining count display', () => {
+  it('shows remaining count for each digit', () => {
+    expect(NUMBER_BAR).toMatch(/remaining/)
+  })
+
+  it('remaining count is 9 - count[n]', () => {
+    expect(NUMBER_BAR).toMatch(/9\s*-\s*counts/)
+  })
+
+  it('renders remaining as a separate span', () => {
+    expect(NUMBER_BAR).toMatch(/digit-remaining/)
+  })
+})
+
+describe('NumberBar — digit disabling', () => {
+  it('applies complete class when count >= 9', () => {
+    // The :class binding should have complete: counts[n] >= 9
+    expect(NUMBER_BAR).toMatch(/complete:\s*counts\[/i)
+    expect(NUMBER_BAR).toMatch(/counts\[[^\]]*\]\s*>=?\s*9/)
+  })
+
+  it('complete class applies opacity reduction', () => {
+    // Source verification: .complete should set opacity < 1
+    expect(NUMBER_BAR).toMatch(/\.complete[^{]*\{[^}]*opacity\s*:/)
+  })
+})
+
+describe('NumberBar — progress bar', () => {
+  it('has progress bar for each digit', () => {
+    expect(NUMBER_BAR).toMatch(/digit-progress/)
+    expect(NUMBER_BAR).toMatch(/digit-fill/)
+  })
+
+  it('progress bar width reflects count / 9 * 100', () => {
+    expect(NUMBER_BAR).toMatch(/counts\[[^\]]*\]\s*\/\s*9\s*\*\s*100/)
+  })
+})
+
+describe('SudokuGrid — highlight class priority', () => {
+  it('defines selected class', () => {
+    expect(SUDOKU_GRID).toMatch(/'?selected'?:\s*.*selected/)
+  })
+
+  it('selected class uses selectedCell prop', () => {
+    expect(SUDOKU_GRID).toMatch(/selected:\s*props\.selectedCell\s*===\s*index/)
+  })
+
+  it('same-value highlighting only when selectedCell >= 0', () => {
+    // The same-value conditional should be inside a selectedCell >= 0 guard
+    const match = SUDOKU_GRID.match(/if\s*\(\s*props\.selectedCell\s*>=?\s*0\s*\).*\{([\s\S]*?)\n\s*\}/)
+    expect(match).not.toBeNull()
+    expect(match![1]).toMatch(/same-value/)
+  })
+
+  it('peer highlighting (related-row/col/region) only when selectedCell >= 0', () => {
+    const match = SUDOKU_GRID.match(/if\s*\(\s*props\.selectedCell\s*>=?\s*0\s*\).*\{([\s\S]*?)\n\s*\}/)
+    expect(match).not.toBeNull()
+    expect(match![1]).toMatch(/related-row/)
+    expect(match![1]).toMatch(/related-col/)
+    expect(match![1]).toMatch(/related-region/)
+  })
+
+  it('same-value excludes the selected cell itself', () => {
+    // classes['same-value'] = ... !isEmpty(...) && ... && index !== props.selectedCell
+    expect(SUDOKU_GRID).toMatch(/same-value[\s\S]*?index\s*!==\s*props\.selectedCell/)
+  })
+
+  it('related-row excludes the selected cell itself', () => {
+    // classes['related-row'] = ... && index !== props.selectedCell
+    expect(SUDOKU_GRID).toMatch(/related-row.*index\s*!==?\s*props\.selectedCell/)
+  })
+
+  it('selected class defined in the classes object (pre-same-value scope)', () => {
+    // selected is defined in the base classes object (before the if block)
+    const classesObj = SUDOKU_GRID.match(/const\s+classes\s*=\s*\{([\s\S]*?)\n\s*\}/)
+    expect(classesObj).not.toBeNull()
+    expect(classesObj![1]).toMatch(/selected/)
+    // same-value and related-row are defined OUTSIDE the base object
+    // (inside the if block), so selected always takes precedence
+  })
+})

--- a/web-ui/tests/tutorialHighlightsThemes.test.ts
+++ b/web-ui/tests/tutorialHighlightsThemes.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Tutorial Highlights Colors + Theme Support Audit
+ *
+ * Verifies:
+ * - Highlight CSS classes exist (blue, green, red, yellow)
+ * - Highlight colors match ADR-0007 spec (color-blind friendly variants)
+ * - Theme prop exists and CSS .theme-* classes are defined
+ * - At least 2 themes are available (beyond default)
+ *
+ * Refs #708
+ */
+
+const SUDOKU_GRID = readFileSync(
+  join(__dirname, '..', 'src', 'components', 'SudokuGrid.vue'),
+  'utf-8',
+)
+
+describe('tutorial highlight CSS classes', () => {
+  it('has highlight-blue CSS class', () => {
+    expect(SUDOKU_GRID).toMatch(/\.cell\.highlight-blue\b/)
+  })
+
+  it('has highlight-green CSS class', () => {
+    expect(SUDOKU_GRID).toMatch(/\.cell\.highlight-green\b/)
+  })
+
+  it('has highlight-red CSS class', () => {
+    expect(SUDOKU_GRID).toMatch(/\.cell\.highlight-red\b/)
+  })
+
+  it('has highlight-yellow CSS class', () => {
+    expect(SUDOKU_GRID).toMatch(/\.cell\.highlight-yellow\b/)
+  })
+
+  it('all four highlight types are applied in getCellClasses', () => {
+    expect(SUDOKU_GRID).toMatch(/highlight-blue.*=\s*isHighlighted/)
+    expect(SUDOKU_GRID).toMatch(/highlight-green.*=\s*isHighlighted/)
+    expect(SUDOKU_GRID).toMatch(/highlight-red.*=\s*isHighlighted/)
+    expect(SUDOKU_GRID).toMatch(/highlight-yellow.*=\s*isHighlighted/)
+  })
+})
+
+describe('highlight color specification', () => {
+  it('highlight-blue uses blue-based background with box-shadow inset', () => {
+    const match = SUDOKU_GRID.match(/\.cell\.highlight-blue\s*\{([^}]+)\}/)
+    expect(match).not.toBeNull()
+    const body = match![1]
+    expect(body).toMatch(/background/)
+    expect(body).toMatch(/box-shadow/)
+  })
+
+  it('highlight-green uses green-based background with box-shadow inset', () => {
+    const match = SUDOKU_GRID.match(/\.cell\.highlight-green\s*\{([^}]+)\}/)
+    expect(match).not.toBeNull()
+    const body = match![1]
+    expect(body).toMatch(/background/)
+    expect(body).toMatch(/box-shadow/)
+  })
+
+  it('highlight-red uses red-based background with box-shadow inset', () => {
+    const match = SUDOKU_GRID.match(/\.cell\.highlight-red\s*\{([^}]+)\}/)
+    expect(match).not.toBeNull()
+    const body = match![1]
+    expect(body).toMatch(/background/)
+    expect(body).toMatch(/box-shadow/)
+  })
+
+  it('highlight-yellow uses yellow-based background with box-shadow inset', () => {
+    const match = SUDOKU_GRID.match(/\.cell\.highlight-yellow\s*\{([^}]+)\}/)
+    expect(match).not.toBeNull()
+    const body = match![1]
+    expect(body).toMatch(/background/)
+    expect(body).toMatch(/box-shadow/)
+  })
+
+  it('has colorblind mode override for all highlight colors', () => {
+    // .grid.colorblind .cell.highlight-{color} should exist for all 4
+    expect(SUDOKU_GRID).toMatch(/\.grid\.colorblind\s+\.cell\.highlight-blue/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.colorblind\s+\.cell\.highlight-green/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.colorblind\s+\.cell\.highlight-red/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.colorblind\s+\.cell\.highlight-yellow/)
+  })
+
+  it('has dark mode override for all highlight colors', () => {
+    // .grid.dark .cell.highlight-{color} should exist for all 4
+    expect(SUDOKU_GRID).toMatch(/\.grid\.dark\s+\.cell\.highlight-blue/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.dark\s+\.cell\.highlight-green/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.dark\s+\.cell\.highlight-red/)
+    expect(SUDOKU_GRID).toMatch(/\.grid\.dark\s+\.cell\.highlight-yellow/)
+  })
+
+  it('highlights use !important to ensure priority over other styles', () => {
+    // At least one highlight color should use !important on background
+    const allHighlights = SUDOKU_GRID.match(/\.cell\.highlight-\w+\s*\{[^}]*\}/g) || []
+    const withImportant = allHighlights.filter(h => h.includes('!important'))
+    // Most highlights should use !important for background
+    expect(withImportant.length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('theme support', () => {
+  it('has theme prop defined in component interface', () => {
+    expect(SUDOKU_GRID).toMatch(/theme\??:\s*string/)
+  })
+
+  it('theme is passed to grid CSS class', () => {
+    // Should have something like :class="{ ... ['theme-' + theme]: theme !== 'default' }"
+    expect(SUDOKU_GRID).toMatch(/\['theme-'\s*\+\s*theme\]/)
+  })
+
+  it('has wood theme CSS classes', () => {
+    expect(SUDOKU_GRID).toMatch(/\.grid\.theme-wood\b/)
+  })
+
+  it('has neon theme CSS classes', () => {
+    expect(SUDOKU_GRID).toMatch(/\.grid\.theme-neon\b/)
+  })
+
+  it('has minimal theme CSS classes', () => {
+    expect(SUDOKU_GRID).toMatch(/\.grid\.theme-minimal\b/)
+  })
+
+  it('has at least 3 themes (beyond default)', () => {
+    const themeClasses = SUDOKU_GRID.match(/\.grid\.theme-(\w+)\b/g) || []
+    const uniqueThemes = new Set(themeClasses)
+    // wood, neon, minimal = 3 unique theme class prefixes
+    expect(uniqueThemes.size).toBeGreaterThanOrEqual(3)
+  })
+
+  it('each theme has dark mode variant (where applicable)', () => {
+    // Wood theme has .grid.theme-wood.dark
+    expect(SUDOKU_GRID).toMatch(/\.grid\.theme-wood\.dark\b/)
+    // Minimal theme has .grid.theme-minimal.dark
+    expect(SUDOKU_GRID).toMatch(/\.grid\.theme-minimal\.dark\b/)
+    // At least 2 of 3 themes support dark mode
+    const darkThemeMatches = SUDOKU_GRID.match(/\.grid\.theme-\w+\.dark\b/g) || []
+    expect(new Set(darkThemeMatches).size).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
Closes #707
Closes #708

## Changes
Two new test files (33 tests total):

### `numberBarHighlightPriority.test.ts` (14 tests) — Refs #707
- NumberBar: remaining count (9 - count[n]), digit disabling at >= 9, opacity
- NumberBar: progress bar width reflects count / 9 * 100
- SudokuGrid: selected class uses selectedCell prop
- same-value/peer highlighting only when selectedCell >= 0
- selected defined in base classes (before conditional block)

### `tutorialHighlightsThemes.test.ts` (19 tests) — Refs #708
- 4 highlight CSS classes (blue, green, red, yellow) with box-shadow inset
- Colorblind mode overrides for all 4 highlight colors
- Dark mode overrides for all 4 highlight colors
- !important usage on highlights for priority
- Wood, neon, minimal themes (3 total)
- Dark mode variants for themes (wood, minimal)
- theme prop and CSS class binding

## Testing
- [x] All 33 new tests pass
- [x] Full suite: 288 tests pass (33 files)
- [x] No source changes (test-only)
