### PR TITLE
feat: add SolverConfig support + static convenience methods to SolverWithSteps

### DIFF
--- a/packages/solver/src/SolverWithSteps.ts
+++ b/packages/solver/src/SolverWithSteps.ts
@@ -1,6 +1,7 @@
-import type { Board } from './Board'
+import { Board } from './Board'
+import { BoardReader } from './BoardReader'
 import { Coord } from './Coord'
-import { Solver } from './Solver'
+import { Solver, SolverConfig } from './Solver'
 import { StepRecorder } from './StepRecorder'
 import { SolvingProgress } from './SolvingProgress'
 
@@ -24,8 +25,8 @@ import { SolvingProgress } from './SolvingProgress'
 export class SolverWithSteps {
   private solver: Solver
 
-  constructor() {
-    this.solver = new Solver()
+  constructor(config?: SolverConfig) {
+    this.solver = new Solver(config)
   }
 
   /**
@@ -42,6 +43,16 @@ export class SolverWithSteps {
     }
 
     return [solution, recorder.progress]
+  }
+
+  /**
+   * Convenience method to solve a puzzle string and get step-by-step results.
+   */
+  static solveWithSteps(puzzleString: string): [Board | null, SolvingProgress]
+  static solveWithSteps(puzzleString: string, config: SolverConfig): [Board | null, SolvingProgress]
+  static solveWithSteps(puzzleString: string, config?: SolverConfig): [Board | null, SolvingProgress] {
+    const board = BoardReader.fromString(puzzleString, Board)
+    return new SolverWithSteps(config).solveWithSteps(board)
   }
 }
 

--- a/packages/solver/tests/SolverWithSteps.test.ts
+++ b/packages/solver/tests/SolverWithSteps.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { Board } from '../src/Board'
 import { BoardReader } from '../src/BoardReader'
 import { SolverWithSteps } from '../src/SolverWithSteps'
+import { SolverConfig } from '../src/Solver'
 
 const HARD_PUZZLE = '.....6....59.....82....8....45........3........6..3.54...325..6..................'
 
@@ -34,5 +35,31 @@ describe('SolverWithSteps', () => {
 
     const summary = progress.summary()
     expect(summary).toContain('Solving Progress')
+  })
+
+  it('accepts SolverConfig', () => {
+    const board = BoardReader.fromString(HARD_PUZZLE, Board)
+    const config = new SolverConfig()
+    const wrapper = new SolverWithSteps(config)
+    const [solution, progress] = wrapper.solveWithSteps(board)
+
+    expect(solution).not.toBeNull()
+    expect(progress.steps.length).toBeGreaterThan(0)
+  })
+
+  it('static solveWithSteps from puzzle string', () => {
+    const [solution, progress] = SolverWithSteps.solveWithSteps(HARD_PUZZLE)
+
+    expect(solution).not.toBeNull()
+    expect(progress.steps.length).toBeGreaterThan(0)
+    expect(solution!.isValid()).toBe(true)
+  })
+
+  it('static solveWithSteps with config', () => {
+    const config = new SolverConfig()
+    const [solution, progress] = SolverWithSteps.solveWithSteps(HARD_PUZZLE, config)
+
+    expect(solution).not.toBeNull()
+    expect(progress.steps.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary
Added missing features to `SolverWithSteps.ts` to match the Kotlin source:
- Constructor now accepts optional `SolverConfig` parameter
- Added static `solveWithSteps(puzzleString)` convenience method
- Added static `solveWithSteps(puzzleString, config)` overload

## Changes
- `packages/solver/src/SolverWithSteps.ts` — added config support + 2 static methods
- `packages/solver/tests/SolverWithSteps.test.ts` — 3 new tests (6 total)

## Testing
- TS: 6/6 SolverWithSteps tests pass (455/456 total, 1 flaky MutantFish unrelated)
- Kotlin: BUILD SUCCESSFUL (all tests pass)

Refs #695
Unblocks #696