### PR TITLE
fix: move StartLimitIntervalSec/StartLimitBurst to [Unit] section

### DIFF
--- a/scripts/sudoku-solver-staging.service
+++ b/scripts/sudoku-solver-staging.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Sudoku Dojo (Staging)
 After=network.target
+StartLimitIntervalSec=60s
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -13,8 +15,6 @@ Environment=BUILD_TIMESTAMP_FILE=/opt/sudoku-solver-staging/.build-timestamp
 ExecStart=/opt/sudoku-solver-staging/bin/web
 Restart=on-failure
 RestartSec=2s
-StartLimitIntervalSec=60s
-StartLimitBurst=5
 
 # Security hardening
 NoNewPrivileges=yes


### PR DESCRIPTION
Fixes #753

## Bug
Systemd 255 silently ignores StartLimitIntervalSec and StartLimitBurst when placed in [Service] — they must be in [Unit] to take effect. Without this fix, rate limiting never engages, resulting in indefinite crash loops.

## Changes
Moved 2 lines from [Service] to [Unit] section in scripts/sudoku-solver-staging.service.

## Testing
- Diff shows only the 2-line move, no other changes
- No other systemd directives in wrong sections