### PR TITLE
fix: correct Empty Rectangle ERI selection via 2×2 empty rectangle check (#760)

### DIFF
--- a/packages/solver/src/Eliminators.ts
+++ b/packages/solver/src/Eliminators.ts
@@ -805,10 +805,14 @@ export class TwoStringKiteCandidateEliminator implements CandidateEliminator {
 // ---------------------------------------------------------------------------
 
 /**
- * Empty Rectangle: In a 3×3 box, if a candidate's cells are confined to
- * one row + at most 2 columns (or one column + at most 2 rows), find a
- * strong link outside the box that intersects and eliminate the candidate
- * from the chain's remote intersection.
+ * Empty Rectangle: In a 3×3 box, find a 2×2 sub-grid where all 4 cells
+ * are empty of the candidate (the "empty rectangle"). The cell diagonally
+ * opposite the empty rectangle is the ERI (Empty Rectangle Intersection).
+ * If the ERI contains the candidate and aligns with a strong link outside
+ * the box, the candidate can be eliminated from the far intersection.
+ *
+ * Reference: https://www.sudokuwiki.org/Empty_Rectangles (deprecated in
+ * favor of Rectangle Elimination, but still a valid pattern).
  */
 export class EmptyRectangleCandidateEliminator implements CandidateEliminator {
     readonly displayName = 'Empty Rectangle'
@@ -852,20 +856,49 @@ export class EmptyRectangleCandidateEliminator implements CandidateEliminator {
             if (cols.length === 2) rowLinks.set(r, [cols[0], cols[1]])
         }
 
+        // Helper: check if cell (r, c) has the candidate
+        const hasCandidate = (r: number, c: number): boolean =>
+            !!(board.candidatePattern(Coord.all[r * 9 + c]) & mask)
+
         for (const region of CoordGroup.region) {
-            const cells = region.coords.filter(c => board.candidatePattern(c) & mask)
-            if (cells.length < 2) continue
+            // Compute global row/col of the box's top-left corner
+            const boxRow = region.coords[0].row
+            const boxCol = region.coords[0].col
 
-            for (const eri of cells) {
-                // ERI must have other candidates in both its row and column
-                // (within the box) — forming an L-shaped pattern.
-                const hasRowBuddy = cells.some(c => c !== eri && c.row === eri.row)
-                const hasColBuddy = cells.some(c => c !== eri && c.col === eri.col)
-                if (!hasRowBuddy || !hasColBuddy) continue
+            // Find all 2×2 sub-grids within this box where ALL 4 cells
+            // are empty of the candidate (the "empty rectangle").
+            // The ERI is the cell diagonally opposite the empty rectangle.
+            //
+            // 4 possible 2×2 placements within a 3×3:
+            //   [0,0]→(2,2)   [0,1]→(2,0)   [1,0]→(0,2)   [1,1]→(0,0)
+            const eriCandidates: [number, number][] = []
 
-                const eriBox = eri.region
-                const eriRow = eri.row
-                const eriCol = eri.col
+            // Top-left 2×2 empty → ERI at bottom-right
+            if (!hasCandidate(boxRow, boxCol) && !hasCandidate(boxRow, boxCol + 1) &&
+                !hasCandidate(boxRow + 1, boxCol) && !hasCandidate(boxRow + 1, boxCol + 1)) {
+                eriCandidates.push([boxRow + 2, boxCol + 2])
+            }
+            // Top-right 2×2 empty → ERI at bottom-left
+            if (!hasCandidate(boxRow, boxCol + 1) && !hasCandidate(boxRow, boxCol + 2) &&
+                !hasCandidate(boxRow + 1, boxCol + 1) && !hasCandidate(boxRow + 1, boxCol + 2)) {
+                eriCandidates.push([boxRow + 2, boxCol])
+            }
+            // Bottom-left 2×2 empty → ERI at top-right
+            if (!hasCandidate(boxRow + 1, boxCol) && !hasCandidate(boxRow + 1, boxCol + 1) &&
+                !hasCandidate(boxRow + 2, boxCol) && !hasCandidate(boxRow + 2, boxCol + 1)) {
+                eriCandidates.push([boxRow, boxCol + 2])
+            }
+            // Bottom-right 2×2 empty → ERI at top-left
+            if (!hasCandidate(boxRow + 1, boxCol + 1) && !hasCandidate(boxRow + 1, boxCol + 2) &&
+                !hasCandidate(boxRow + 2, boxCol + 1) && !hasCandidate(boxRow + 2, boxCol + 2)) {
+                eriCandidates.push([boxRow, boxCol])
+            }
+
+            for (const [eriRow, eriCol] of eriCandidates) {
+                // ERI must contain the candidate (intersection of Empty Rectangle Lines)
+                if (!hasCandidate(eriRow, eriCol)) continue
+
+                const eriBox = Coord.all[eriRow * 9 + eriCol].region
 
                 // Row strong links: near end shares column with ERI
                 // Target = (ERI.row, farEnd.col)

--- a/packages/solver/src/Solver.ts
+++ b/packages/solver/src/Solver.ts
@@ -2,6 +2,7 @@ import type { Board } from './Board'
 import type { CandidateEliminator } from './Eliminators'
 import {
     SimpleCandidateEliminator,
+    EmptyRectangleCandidateEliminator,
     GroupCandidateEliminator,
     HiddenSubsetCandidateEliminator,
     ExclusionCandidateEliminator,
@@ -83,12 +84,12 @@ export class SolverConfig {
  * Default eliminators: all 11 production-ready TS eliminators.
  *
  * Excluded:
- *   EmptyRectangle — makes incorrect eliminations (known bug, breaks solver)
  *   DeathBlossom  — too slow for default set (combinatorial explosion)
  */
 function defaultEliminators(): readonly CandidateEliminator[] {
     return [
         new SimpleCandidateEliminator(),
+        new EmptyRectangleCandidateEliminator(),
         new GroupCandidateEliminator(),
         new HiddenSubsetCandidateEliminator(),
         new ExclusionCandidateEliminator(9),

--- a/packages/solver/tests/EmptyRectangle.test.ts
+++ b/packages/solver/tests/EmptyRectangle.test.ts
@@ -192,9 +192,8 @@ describe('EmptyRectangleCandidateEliminator — rejects invalid patterns', () =>
 
     it('does NOT eliminate when ERI corner has no candidate (L-shaped gap)', () => {
         // L-shaped pattern in box 0: (0,1),(0,2) + (1,0),(2,0)
-        // The corner cell (0,0) does NOT have the candidate → no valid ERI.
-        // This is a known limitation: the algorithm requires the ERI cell
-        // itself to hold the candidate to be considered.
+        // The 2×2 at (1,1)→(2,2) is empty → ERI would be (0,0).
+        // But (0,0) does not have the candidate, so no valid ERI.
         const value = 5
         const positions: [number, number][] = [
             [0, 1], [0, 2],  // Row arm of L in box 0


### PR DESCRIPTION
## Summary

Fixes the EmptyRectangleCandidateEliminator correctness bug (#760) by replacing the heuristic ERI selection (row buddy + column buddy) with the correct algorithm from SudokuWiki.

## Root Cause

The previous algorithm iterated over candidate cells and checked for row/column buddies to identify ERI candidates. This heuristic was insufficient — it selected ERIs in boxes without a valid empty rectangle pattern (no 2×2 sub-grid of empty cells), causing incorrect eliminations.

Specifically, on the G4 hard puzzle, the algorithm falsely eliminated candidate 2 from (4,3) because it used (2,3) as ERI in box 1 — but box 1 has no 2×2 empty rectangle for value 2.

## Fix

Replaced the ERI selection logic with the correct algorithm per [SudokuWiki](https://www.sudokuwiki.org/Empty_Rectangles):

1. For each box and value, check all 4 possible 2×2 sub-grids
2. If a 2×2 sub-grid is entirely empty of the candidate → empty rectangle found
3. The ERI is the cell diagonally opposite the empty rectangle
4. ERI must contain the candidate (intersection of Empty Rectangle Lines)
5. Strong link validation and target elimination unchanged

The eliminator is now re-enabled in the default eliminator set.

## Changes

- `Eliminators.ts`: Rewrote `_eliminateValue` with 2×2 empty rectangle detection
- `Solver.ts`: Added EmptyRectangleCandidateEliminator to imports and defaults, removed exclusion comment
- `EmptyRectangle.test.ts`: Updated L-shaped gap test comment

## Verification

- All 10 EmptyRectangle tests pass ✓
- All 8 SolverParity tests pass (including G4 hard puzzle) ✓
- Full test suite: 462/463 pass (1 flaky MutantFish timeout, pre-existing)

Refs #760