### PR TITLE
feat: add CI solver parity workflow and README badge (#761)

### DIFF
--- a/.github/workflows/solver-parity.yml
+++ b/.github/workflows/solver-parity.yml
@@ -1,0 +1,41 @@
+# ADR-0010: TS/Kotlin solver parity CI guard.
+# Runs TS SolverParity tests on every PR and push to master.
+# Must pass before merge for any PR touching solver code.
+
+name: Solver Parity
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/solver/**'
+      - '.github/workflows/solver-parity.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'packages/solver/**'
+      - '.github/workflows/solver-parity.yml'
+  workflow_dispatch:
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/solver/package-lock.json
+
+      - name: Install dependencies
+        working-directory: packages/solver
+        run: npm ci
+
+      - name: Run solver parity tests
+        working-directory: packages/solver
+        run: npx vitest run tests/SolverParity.test.ts --reporter=verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Sudoku Dojo — High-Level Design & Architecture
 
+[![CI Build & Analysis](https://github.com/sudoku-solver-bot/sudoku-solver/actions/workflows/gradle.yml/badge.svg)](https://github.com/sudoku-solver-bot/sudoku-solver/actions/workflows/gradle.yml)
+[![Solver Parity](https://github.com/sudoku-solver-bot/sudoku-solver/actions/workflows/solver-parity.yml/badge.svg)](https://github.com/sudoku-solver-bot/sudoku-solver/actions/workflows/solver-parity.yml)
+
 An **educational** Sudoku platform that teaches 21 solving techniques through interactive tutorials, belt-rank progression, and daily challenges. Target audience: learners mastering Sudoku logic + contributors extending the system.
 
 


### PR DESCRIPTION
## Summary

Adds CI enforcement for TS/Kotlin solver parity per ADR-0010.

## Changes

- **`.github/workflows/solver-parity.yml`** — new CI job that runs `SolverParity.test.ts` on every PR/push touching solver code
- **`README.md`** — added Solver Parity badge alongside existing CI badge

## CI Workflow

- Runs `npx vitest run tests/SolverParity.test.ts --reporter=verbose`
- Triggers on PRs and pushes to master when solver code changes
- Fails if any parity divergence is detected
- Timeout: 10 minutes

## Verification

- All 8 SolverParity tests pass locally ✓
- CI will validate on this PR

Refs #761